### PR TITLE
Console effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ idePackagePrefix := Some("fx")
 
 run / fork := true
 
+run / connectInput := true
+
 classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
 
 javaOptions ++= Seq(

--- a/src/main/scala/Bind.scala
+++ b/src/main/scala/Bind.scala
@@ -25,6 +25,9 @@ opaque type Bind = Unit
 object Bind:
   given Bind = ()
 
+extension [A](fa: List[A])
+  def bind: A * Bind = ???
+
 extension [R, A](fa: Either[R, A])
   def bind: A * Bind * Errors[R] = fa.fold(_.shift, identity)
 

--- a/src/main/scala/Console.scala
+++ b/src/main/scala/Console.scala
@@ -3,71 +3,85 @@ package fx
 import fx.*
 import scala.annotation.implicitNotFound
 import scala.io.StdIn.readLine
+import scala.annotation.tailrec
+
+class EndOfLine extends RuntimeException("reached end of line")
 
 @implicitNotFound(
   "Missing capability:\n* Console"
 )
 trait Console:
-  def consoleWrite(s: String): Unit
-  def consoleReadLine(): Option[String]
 
-extension (c: Console)
-  def consoleWriteLine(s: String): Unit = 
-    c.consoleWrite(s + "\n")
+  def read(): String 
 
-object StandardConsole extends Console:
-  def consoleWrite(s: String): Unit = print(s)
-  def consoleReadLine(): Option[String] = Some(readLine())
+  extension (s: String)
+    def write(): Unit
+    def writeLine(): Unit
 
-class FakeConsole(var input: String) extends Console:
+object Console:
+  given default(using Throws[EndOfLine]): Console = StandardConsole()
+
+/** If your method is not an extension then it needs side syntax like these or
+  * users would need to summon.
+  */
+def read(): String * Console =
+  summon[Console].read()
+
+class StandardConsole(using Throws[EndOfLine]) extends Console:
+  def read(): String =
+    val r = readLine()
+    if (r != null) r
+    else throw EndOfLine()
+
+  extension (s: String)
+    def write(): Unit = print(s)
+    def writeLine(): Unit = println(s)
+
+class FakeConsole(var input: String)(using Throws[EndOfLine]) extends Console:
   var output: String = ""
 
-  def consoleWrite(s: String): Unit = output += s
-  def consoleReadLine(): Option[String] =
-    if input.isEmpty then
-      None
+  def read(): String =
+    if input.isEmpty then throw EndOfLine()
     else
       input.split('\n') match
         case Array(r, rest*) =>
           input = rest.mkString("\n")
-          Some(r)
+          r
         case _ =>
-          None
+          null
 
-// here I need to use summon[Console] over and over...
-def program1: String * Console * Errors[String] =
-  summon[Console].consoleWrite("what is your name?")
-  summon[Console].consoleReadLine() match
-    case None => 
-      "end of input".raise
-    case Some("") =>
-      summon[Console].consoleWriteLine("empty name")
-      program1
-    case Some("me") =>
-      summon[Console].consoleWriteLine("wrong name")
+  extension (s: String)
+    def write(): Unit = output += s
+    def writeLine(): Unit = output += (s + "\n")
+
+@tailrec
+def program: String * Console * Errors[String] =
+  "what is your name?".writeLine()
+  read() match
+    case "" =>
+      "empty name".writeLine()
+      program
+    case "me" =>
+      "wrong name!".writeLine()
       "wrong name".raise
-    case Some(name) =>
-      name
+    case name =>
+      s"hello $name"
 
-// create some boilerplate-less methods
-def consoleWrite(s: String): Unit * Console =
-  summon[Console].consoleWrite(s)
-def consoleWriteLine(s: String): Unit * Console =
-  summon[Console].consoleWriteLine(s)
-def consoleReadLine(): Option[String] * Console =
-  summon[Console].consoleReadLine()
+@main def consoleStandard() =
+  import fx.runtime
+  import fx.unsafe.unsafeExceptions
 
-// here I need to use summon[Console] over and over...
-def program2: String * Console * Errors[String] =
-  consoleWrite("what is your name?")
-  consoleReadLine() match
-    case None => 
-      "end of input".raise
-    case Some("") =>
-      consoleWriteLine("empty name")
-      program2
-    case Some("me") =>
-      consoleWriteLine("wrong name")
-      "wrong name".raise
-    case Some(name) =>
-      name
+  val value: String =
+    run(program)
+
+@main def consoleFake() =
+  import fx.runtime
+  import fx.unsafe.unsafeExceptions
+  given Console = FakeConsole("")
+  val value: String =
+    try 
+      run(program)
+    catch 
+      case eol: EndOfLine => "Reached end"
+    
+  println(value)

--- a/src/main/scala/Fiber.scala
+++ b/src/main/scala/Fiber.scala
@@ -1,0 +1,27 @@
+package fx
+
+import java.util.concurrent.Future
+import java.util.concurrent.CompletableFuture
+
+opaque type Fiber[A] = Future[A]
+
+extension [A](fiber: Fiber[A])
+  def join: A * Structured = fiber.get
+  def cancel(mayInterrupt: Boolean = true): Boolean * Structured =
+    fiber.cancel(mayInterrupt)
+
+def uncancellable[A](fn: () => A): () => A = {
+  val promise = new CompletableFuture[A]()
+  Thread
+    .ofVirtual()
+    .start(() => {
+      try promise.complete(fn())
+      catch
+        case t: Throwable =>
+          promise.completeExceptionally(t)
+    })
+  () => promise.join
+}
+
+def fork[B](f: () => B): Fiber[B] * Structured =
+  summon[Structured].forked(callableOf(f))

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -5,10 +5,7 @@ import java.time.Duration
 import java.util.concurrent.CancellationException
 import cats.syntax.validated
 
-def program2: Int * Bind =
-  Right(1).bind + Right(2).bind
 
-  
 def program: Int
   * Bind
   * Errors[String] =
@@ -23,17 +20,13 @@ def program: Int
   val value: Int | String =
     run(program + program)
 
-  val value2: Int =
-    run(program2 + program2)
-
-  val threads = parallel(
+  val results = structured(parallel(
     (
-      () => Thread.currentThread.getId,
-      () => Thread.currentThread.getId,
-      () => Thread.currentThread.getId
+      () => "1",
+      () => 0,
+      () => 47.0
     )
-  )
+  ))
 
-  println(threads)
+  println(results)
   println(value)
-  println(value2)

--- a/src/main/scala/Parallel.scala
+++ b/src/main/scala/Parallel.scala
@@ -25,16 +25,16 @@ inline def parallel[X <: Tuple](
     inline f: X
 )(using
     TupledVarargs[Function0, X]#Args =:= X
-): TupledVarargs[Function0, X]#Result = structured({
+): TupledVarargs[Function0, X]#Result * Structured = 
   val results =
     f.toList
       .map(fa => fa.asInstanceOf[() => Any])
       .map(fork(_))
-  join
+  joinAll
   Tuple
-    .fromArray(results.map(_.get).toArray)
+    .fromArray(results.map(_.join).toArray)
     .asInstanceOf[TupledVarargs[Function0, X]#Result]
-})
+
 
 inline def parallelMap[X <: Tuple, C](
     inline f: X,
@@ -46,8 +46,8 @@ inline def parallelMap[X <: Tuple, C](
     f.toList
       .map(fa => fa.asInstanceOf[() => Any])
       .map(fork(_))
-  join
+  joinAll
   fc(Tuple
-    .fromArray(results.map(_.get).toArray)
+    .fromArray(results.map(_.join).toArray)
     .asInstanceOf[TupledVarargs[Function0, X]#Result])
 })

--- a/src/main/scala/Resource.scala
+++ b/src/main/scala/Resource.scala
@@ -99,9 +99,9 @@ def parallelZip[X <: Tuple, C](
         fa.toList
           .map(fa => () => fa.asInstanceOf[Resource[Any]].bind)
           .map(fork(_))
-      join
+      joinAll
       val r = Tuple
-        .fromArray(results.map(_.get).toArray)
+        .fromArray(results.map(_.join).toArray)
         .asInstanceOf[TupledVarargs[Resource, X]#Result]
       f(r)
     })

--- a/src/main/scala/Throws.scala
+++ b/src/main/scala/Throws.scala
@@ -1,0 +1,24 @@
+package fx
+
+import scala.annotation.implicitNotFound
+
+// TODO this can `erased` with scala3 still experimental erased feature
+@implicitNotFound(
+  "Missing capability:\n" +
+    "* Throws[${R}]\n" +
+    "alternatively you may resolve this call with \n" +
+    "```scala\nhandle(f)(recover)\n```\n" +
+    "or\n ignored thrown exceptions with import fx.unsafe.unsafeExceptions`"
+)
+sealed trait Throws[-R <: Exception]
+private[fx] object Handled extends Throws[Nothing]
+
+inline def handle[R <: Exception, A](
+    inline f: A * Throws[R]
+)(inline recover: (R) => A): A =
+  try
+    import fx.unsafe.unsafeExceptions
+    f
+  catch
+    case r: R =>
+      recover(r)

--- a/src/main/scala/Unsafe.scala
+++ b/src/main/scala/Unsafe.scala
@@ -1,0 +1,5 @@
+package fx
+
+object unsafe:
+  given unsafeExceptions[R <: Exception]: Throws[R] =
+    Handled.asInstanceOf[Throws[R]]


### PR DESCRIPTION
This is a PR to discuss some of the issues around creating new effects. The idea is to have a `Console` effect:

- which provides two methods: `consoleReadLine` and `consoleWrite`,
- where we define a `consoleWriteLine` method derived from those,
- where we have more than one implementation: one for testing and one for "real console".

Some of the questions are?

- how do we make using the effects ergonomic? without manually-written versions with `* Console` they require `summon[Console]`. Is that bad?
- is `extension` the best way to have "derived methods"?
- how do we inject the different implementations in a `main` program?
- I would like to state that if I use `StandardConsole` I might also need to bring `Errors[IOException]` to the mix. How can I do that?