### PR TITLE
toOption - toEither runtime tests

### DIFF
--- a/src/test/scala/BindTests.scala
+++ b/src/test/scala/BindTests.scala
@@ -1,6 +1,5 @@
 package fx
 
-import cats.syntax.option._
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
 
@@ -10,17 +9,21 @@ object BindTests extends Properties("Bind Tests"):
     run(effect) == a + b
   }
 
-  property("Binding two values of different types") = forAll { (a: Int, b: Int) =>
-    val effect: Int * Control[None.type] = Right(a).bind + Some(b).bind
-    run(effect) == a + b
+  property("Binding two values of different types") = forAll {
+    (a: Int, b: Int) =>
+      val effect: Int * Control[None.type] = Right(a).bind + Some(b).bind
+      run(effect) == a + b
   }
 
-  property("Short-circuiting with Either.Left") = forAll { (n: Int, s: String) =>
-    val effect: Int * Control[String | None.type] = Left[String, Int](s).bind + Some(n).bind
-    run(effect) == s
+  property("Short-circuiting with Either.Left") = forAll {
+    (n: Int, s: String) =>
+      val effect: Int * Control[String | None.type] =
+        Left[String, Int](s).bind + Some(n).bind
+      run(effect) == s
   }
 
   property("Short-circuiting with Option.None") = forAll { (n: Int) =>
-    val effect: Int * Control[None.type] = Right(n).bind + none[Int].bind
+    val effect: Int * Control[None.type] =
+      Right(n).bind + Option.empty[Int].bind
     run(effect) == None
   }

--- a/src/test/scala/RuntimeTests.scala
+++ b/src/test/scala/RuntimeTests.scala
@@ -2,7 +2,6 @@ package fx
 
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
-import fx.*
 
 object RuntimeTests extends Properties("Runtime Tests"):
   property("Either binding toOption") = forAll { (a: Int, b: Int) =>


### PR DESCRIPTION
This PR contains:
- Some happy and unhappy path tests for the methods `toOption` and `toEither` from the RunTime
- A possible way for removing `import cats.syntax.option._` dependency in the None.type construction using `Option.empty[T]`

Some questions for clarifying what is the behavior that we want to have.

For short-circuiting scenarios:

Should the `toEither` be visible for a `A * Control[None.type]` effect? because using the current implementation It would return a `Left(None)` and It doesn't look right.