### PR TITLE
Bumps SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 ThisBuild / scalaVersion := "3.1.1-RC1"
 ThisBuild / organization := "com.47deg"
+ThisBuild / versionScheme := Some("early-semver")
 
 addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; test")
 addCommandAlias("ci-publish", "github; ci-release")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.0-M1
+sbt.version = 1.6.0-RC1


### PR DESCRIPTION
... and sets `early-semver` settings, which means:

> Early Semantic Versioning that would keep binary compatibility across patch updates within 0.Y.z (for instance 0.13.0 and 0.13.2). Once it goes 1.0.0, it follows the regular Semantic Versioning where 1.1.0 is bincompat with 1.0.0.