### PR TITLE
CU-2f7j85w Submodule jdbc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,12 @@ addCommandAlias("ci-publish", "github; ci-release")
 publish / skip := true
 
 lazy val root =
-  (project in file("./")).aggregate(`scala-fx`, benchmarks, `munit-scala-fx`, documentation, `scalike-jdbc-scala-fx`)
+  (project in file("./")).aggregate(
+    `scala-fx`,
+    benchmarks,
+    `munit-scala-fx`,
+    documentation,
+    `scalike-jdbc-scala-fx`)
 
 lazy val `scala-fx` = project.settings(scalafxSettings: _*)
 

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ lazy val scalalikeSettings: Seq[Def.Setting[_]] =
       scalikejdbc,
       h2Database,
       logback,
+      postgres,
       scalacheck % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,11 @@ lazy val scalalikeSettings: Seq[Def.Setting[_]] =
       h2Database,
       logback,
       postgres,
-      scalacheck % Test
+      scalacheck % Test,
+      testContainers % Test,
+      testContainersMunit % Test,
+      testContainersPostgres % Test,
+      flyway % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,11 @@ lazy val `munit-scala-fx` = (project in file("./munit-scalafx"))
   )
   .dependsOn(`scala-fx`)
 
+lazy val `scalike-jdbc-scala-fx` = project
+  .dependsOn(`scala-fx`)
+  .settings(publish / skip := true)
+  .settings(scalalikeSettings)
+
 lazy val scalafxSettings: Seq[Def.Setting[_]] =
   Seq(
     classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
@@ -52,6 +57,18 @@ lazy val munitScalaFXSettings = Defaults.itSettings ++ Seq(
     junitInterface
   )
 )
+
+lazy val scalalikeSettings: Seq[Def.Setting[_]] =
+  Seq(
+    classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
+    javaOptions ++= javaOptionsSettings,
+    autoAPIMappings := true,
+    libraryDependencies ++= Seq(
+      scalikejdbc,
+      h2Database,
+      logback
+    )
+  )
 
 lazy val javaOptionsSettings = Seq(
   "-XX:+IgnoreUnrecognizedVMOptions",

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ addCommandAlias("ci-publish", "github; ci-release")
 publish / skip := true
 
 lazy val root =
-  (project in file("./")).aggregate(`scala-fx`, benchmarks, `munit-scala-fx`, documentation)
+  (project in file("./")).aggregate(`scala-fx`, benchmarks, `munit-scala-fx`, documentation, `scalike-jdbc-scala-fx`)
 
 lazy val `scala-fx` = project.settings(scalafxSettings: _*)
 
@@ -32,7 +32,7 @@ lazy val `munit-scala-fx` = (project in file("./munit-scalafx"))
   .dependsOn(`scala-fx`)
 
 lazy val `scalike-jdbc-scala-fx` = project
-  .dependsOn(`scala-fx`)
+  .dependsOn(`scala-fx`, `munit-scala-fx` % "test -> compile")
   .settings(publish / skip := true)
   .settings(scalalikeSettings)
 
@@ -66,7 +66,8 @@ lazy val scalalikeSettings: Seq[Def.Setting[_]] =
     libraryDependencies ++= Seq(
       scalikejdbc,
       h2Database,
-      logback
+      logback,
+      scalacheck % Test
     )
   )
 

--- a/project/project/Dependencies.scala
+++ b/project/project/Dependencies.scala
@@ -20,6 +20,9 @@ object Dependencies {
     val sbtDependencyUpdates = "1.2.1"
     val jmhGeneratorReflection = "1.35"
     val sbtExplicitDependencies = "0.2.16"
+    val scalikeJdbc = "4.0.0"
+    val h2Database = "2.1.212"
+    val logback = "1.2.11"
   }
 
   object Compile {
@@ -29,6 +32,9 @@ object Dependencies {
     val junit = "junit" % "junit" % Versions.junit
     val munit = "org.scalameta" %% "munit" % Versions.munit
     val junitInterface = "org.scalameta" % "junit-interface" % Versions.junitInterface
+    val scalikejdbc = "org.scalikejdbc" %% "scalikejdbc" % Versions.scalikeJdbc
+    val h2Database = "com.h2database" % "h2" % Versions.h2Database
+    val logback = "ch.qos.logback" % "logback-classic" % Versions.logback
   }
 
   object Test {

--- a/project/project/Dependencies.scala
+++ b/project/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
       "com.dimafeng" %% "testcontainers-scala-munit" % Versions.testContainers
     val testContainersPostgres =
       "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.testContainers
-    val flyway = "org.flywaydb"   % "flyway-core" % Versions.flyway
+    val flyway = "org.flywaydb" % "flyway-core" % Versions.flyway
   }
 
   object Plugins {

--- a/project/project/Dependencies.scala
+++ b/project/project/Dependencies.scala
@@ -24,6 +24,8 @@ object Dependencies {
     val h2Database = "2.1.212"
     val logback = "1.2.11"
     val postgres = "42.4.0"
+    val testContainers = "0.40.8"
+    val flyway = "8.5.12"
   }
 
   object Compile {
@@ -41,6 +43,12 @@ object Dependencies {
   object Test {
     val scalacheck = "org.scalacheck" %% "scalacheck" % Versions.scalacheck
     val postgres = "org.postgresql" % "postgresql" % Versions.postgres
+    val testContainers = "com.dimafeng" %% "testcontainers-scala" % Versions.testContainers
+    val testContainersMunit =
+      "com.dimafeng" %% "testcontainers-scala-munit" % Versions.testContainers
+    val testContainersPostgres =
+      "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.testContainers
+    val flyway = "org.flywaydb"   % "flyway-core" % Versions.flyway
   }
 
   object Plugins {

--- a/project/project/Dependencies.scala
+++ b/project/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
     val scalikeJdbc = "4.0.0"
     val h2Database = "2.1.212"
     val logback = "1.2.11"
+    val postgres = "42.4.0"
   }
 
   object Compile {
@@ -39,6 +40,7 @@ object Dependencies {
 
   object Test {
     val scalacheck = "org.scalacheck" %% "scalacheck" % Versions.scalacheck
+    val postgres = "org.postgresql" % "postgresql" % Versions.postgres
   }
 
   object Plugins {

--- a/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
+++ b/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
@@ -6,17 +6,17 @@ import scalikejdbc.DB.{readOnly, CPContext, NoCPContext}
 import java.sql.SQLException
 import fx.ensure
 
-type Database[A] = (Structured, Control[SQLException]) ?=> Fiber[A]
-type Transaction[A] = (Structured, Control[Exception]) ?=> Fiber[A]
+type Database[A] = Control[SQLException] ?=> A
+type Transaction[A] = Control[Exception] ?=> A
 
 extension (db: DB.type)
   def readOnlyWithControl[A](execution: DBSession => A)(
       using context: CPContext = NoCPContext,
       settings: SettingsProvider = SettingsProvider.default): Database[A] =
-    fork { () => handle(DB.readOnly(execution))((e: SQLException) => e.shift) }
+    handle(DB.readOnly(execution))((e: SQLException) => e.shift)
 
   def localTransaction[A](execution: DBSession => A)(
       using context: CPContext = NoCPContext,
       boundary: TxBoundary[A] = TxBoundary.Exception.exceptionTxBoundary[A],
       settings: SettingsProvider = SettingsProvider.default): Transaction[A] =
-    fork { () => handle(DB.localTx(execution))((e: Exception) => e.shift) }
+    handle(DB.localTx(execution))((e: Exception) => e.shift)

--- a/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
+++ b/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
@@ -1,0 +1,20 @@
+package fx
+
+import scalikejdbc.*
+import scalikejdbc.DB.{CPContext, NoCPContext, readOnly}
+
+import java.sql.SQLException
+import fx.ensure
+
+type Database[A] = (Structured, Control[SQLException]) ?=> Fiber[A]
+
+extension (db: DB)
+  def readOnlyWithControl[A](execution: DBSession => A)(
+      implicit context: CPContext = NoCPContext,
+      settings: SettingsProvider = SettingsProvider.default): Database[A] =
+    fork { () =>
+      try DB.readOnly(execution)
+      catch
+        case e: SQLException => e.shift
+    }
+

--- a/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
+++ b/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
@@ -8,13 +8,12 @@ import fx.ensure
 
 type Database[A] = (Structured, Control[SQLException]) ?=> Fiber[A]
 
-extension (db: DB)
+extension (db: DB.type)
   def readOnlyWithControl[A](execution: DBSession => A)(
-      implicit context: CPContext = NoCPContext,
+      using context: CPContext = NoCPContext,
       settings: SettingsProvider = SettingsProvider.default): Database[A] =
     fork { () =>
       try DB.readOnly(execution)
-      catch
-        case e: SQLException => e.shift
+      catch case e: SQLException => e.shift
     }
 

--- a/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
+++ b/scalike-jdbc-scala-fx/src/main/scala/fx/DatabaseScala.scala
@@ -1,7 +1,7 @@
 package fx
 
 import scalikejdbc.*
-import scalikejdbc.DB.{CPContext, NoCPContext, readOnly}
+import scalikejdbc.DB.{readOnly, CPContext, NoCPContext}
 
 import java.sql.SQLException
 import fx.ensure

--- a/scalike-jdbc-scala-fx/src/test/resources/db/migration/V0__init.sql
+++ b/scalike-jdbc-scala-fx/src/test/resources/db/migration/V0__init.sql
@@ -1,0 +1,8 @@
+CREATE TABLE emp(
+id SERIAL PRIMARY KEY,
+name VARCHAR,
+department VARCHAR
+);
+
+INSERT INTO emp(name, department) VALUES('Ana', 'IT');
+INSERT INTO emp(name, department) VALUES('Mike', 'Marketing');

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
@@ -1,17 +1,10 @@
 package fx
 
-import munit.fx.ScalaFXSuite
 import java.sql.SQLException
 import scalikejdbc.*
 import scalikejdbc.DB.*
 
-class DatabaseTests extends ScalaFXSuite {
-
-  Class.forName("org.postgresql.Driver")
-  ConnectionPool.singleton("jdbc:postgresql://localhost:5432/scalafx", "postgres", "postgres")
-
-  given DB.CPContext = NoCPContext
-  given SettingsProvider = SettingsProvider.default
+class DatabaseSpec extends DatabaseSuite {
 
   testFX("Read only operation executes properly") {
     val names: Database[List[String]] = DB.readOnlyWithControl { implicit session =>
@@ -25,7 +18,9 @@ class DatabaseTests extends ScalaFXSuite {
 
   testFX("Read only shift when tries to execute a non-read only operation") {
     val names: Database[Int] = DB.readOnlyWithControl { implicit session =>
-      sql"update emp set name = 'Never changed in a readonly operation' where id = 1".update.apply()
+      sql"update emp set name = 'Never changed in a readonly operation' where id = 1"
+        .update
+        .apply()
     }
     assertFX(run(structured(names.join.toEither.isLeft)) match {
       case b: Boolean => false
@@ -43,7 +38,9 @@ class DatabaseTests extends ScalaFXSuite {
 
   testFX("Transaction goes wrong and rollback after second update raise an exception") {
     val count: Transaction[Int] = DB.localTransaction { implicit session =>
-      sql"update emp set name = 'Never changed in a failed transaction' where id = 1".update.apply()
+      sql"update emp set name = 'Never changed in a failed transaction' where id = 1"
+        .update
+        .apply()
       sql"update emp set name = 'Empty' where inventing_row = 0".update.apply()
     }
     assertFX(run(structured(count.join.toEither.isLeft)) match {
@@ -51,4 +48,5 @@ class DatabaseTests extends ScalaFXSuite {
       case _ => true
     })
   }
+
 }

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class DatabaseSpec extends DatabaseSuite {
 
-  var counter: AtomicInteger = new AtomicInteger(0)
+  val counter: AtomicInteger = new AtomicInteger(0)
   val names: Database[List[String]] = DB.readOnlyWithControl {
     case given DBSession =>
       counter.incrementAndGet()
@@ -28,7 +28,7 @@ class DatabaseSpec extends DatabaseSuite {
     }).isLeft)
   }
 
-  var txCounter: AtomicInteger = new AtomicInteger(0)
+  val txCounter: AtomicInteger = new AtomicInteger(0)
   val transactResult: Transaction[Int] = DB.localTransaction {
     case given DBSession =>
       txCounter.incrementAndGet()

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
@@ -10,22 +10,16 @@ class DatabaseSpec extends DatabaseSuite {
     val names: Database[List[String]] = DB.readOnlyWithControl { implicit session =>
       sql"select name from emp".map { rs => rs.string("name") }.list.apply()
     }
-    assertFX(run(structured(names.join.toEither.isRight)) match {
-      case b: Boolean => b
-      case _ => false
-    })
+    assertEqualsFX(structured(names.join), List("Ana", "Mike"))
   }
 
   testFX("Read only shift when tries to execute a non-read only operation") {
-    val names: Database[Int] = DB.readOnlyWithControl { implicit session =>
-      sql"update emp set name = 'Never changed in a readonly operation' where id = 1"
-        .update
-        .apply()
-    }
-    assertFX(run(structured(names.join.toEither.isLeft)) match {
-      case b: Boolean => false
-      case _ => true
-    })
+    assertFX(toEither(structured(DB.readOnlyWithControl {
+      case given DBSession =>
+        sql"update emp set name = 'Never changed in a readonly operation' where id = 1"
+          .update
+          .apply()
+    }).join).isLeft)
   }
 
   testFX("Transaction goes well after updating 2 rows.") {
@@ -36,7 +30,7 @@ class DatabaseSpec extends DatabaseSuite {
     assertEqualsFX(run(structured(count.join)), 1)
   }
 
-  testFX("Transaction goes wrong and rollback after second update raise an exception") {
+  testFX("Transaction goes wrong and rollback after second update raises an exception") {
     val count: Transaction[Int] = DB.localTransaction { implicit session =>
       sql"update emp set name = 'Never changed in a failed transaction' where id = 1"
         .update

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSpec.scala
@@ -7,40 +7,39 @@ import scalikejdbc.DB.*
 class DatabaseSpec extends DatabaseSuite {
 
   testFX("Read only operation executes properly") {
-    val names: Database[List[String]] = DB.readOnlyWithControl { implicit session =>
-      sql"select name from emp".map { rs => rs.string("name") }.list.apply()
+    val names: Database[List[String]] = DB.readOnlyWithControl {
+      case given DBSession =>
+        sql"select name from emp".map { rs => rs.string("name") }.list.apply()
     }
-    assertEqualsFX(structured(names.join), List("Ana", "Mike"))
+    assertEqualsFX(names, List("Ana", "Mike"))
   }
 
   testFX("Read only shift when tries to execute a non-read only operation") {
-    assertFX(toEither(structured(DB.readOnlyWithControl {
+    assertFX(toEither(DB.readOnlyWithControl {
       case given DBSession =>
         sql"update emp set name = 'Never changed in a readonly operation' where id = 1"
           .update
           .apply()
-    }).join).isLeft)
+    }).isLeft)
   }
 
   testFX("Transaction goes well after updating 2 rows.") {
-    val count: Transaction[Int] = DB.localTransaction { implicit session =>
-      sql"update emp set name = 'Abc' where id = 1".update.apply()
-      sql"update emp set name = 'Emp' where id = 2".update.apply()
+    val count: Transaction[Int] = DB.localTransaction {
+      case given DBSession =>
+        sql"update emp set name = 'Abc' where id = 1".update.apply()
+        sql"update emp set name = 'Emp' where id = 2".update.apply()
     }
-    assertEqualsFX(run(structured(count.join)), 1)
+    assertEqualsFX(count, 1)
   }
 
   testFX("Transaction goes wrong and rollback after second update raises an exception") {
-    val count: Transaction[Int] = DB.localTransaction { implicit session =>
-      sql"update emp set name = 'Never changed in a failed transaction' where id = 1"
-        .update
-        .apply()
-      sql"update emp set name = 'Empty' where inventing_row = 0".update.apply()
-    }
-    assertFX(run(structured(count.join.toEither.isLeft)) match {
-      case b: Boolean => false
-      case _ => true
-    })
+    assertFX(toEither(DB.localTransaction {
+      case given DBSession =>
+        sql"update emp set name = 'Never changed in a failed transaction' where id = 1"
+          .update
+          .apply()
+        sql"update emp set name = 'Empty' where inventing_row = 0".update.apply()
+    }).isLeft)
   }
 
 }

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSuite.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseSuite.scala
@@ -1,0 +1,36 @@
+package fx
+
+import munit.fx.ScalaFXSuite
+
+import scalikejdbc.*
+import scalikejdbc.DB.*
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import org.flywaydb.core.Flyway
+import org.testcontainers.utility.DockerImageName
+
+class DatabaseSuite extends ScalaFXSuite with TestContainerForAll {
+
+  private val postgresV = "12.6"
+
+  private val dbName = "scalafx"
+  private val dbUserName = "test"
+  private val dbPassword = "password"
+  private val driverName = "org.postgresql.Driver"
+
+  override val containerDef: PostgreSQLContainer.Def = PostgreSQLContainer.Def(
+    DockerImageName.parse(s"postgres:$postgresV"),
+    databaseName = dbName,
+    username = dbUserName,
+    password = dbPassword
+  )
+
+  override def afterContainersStart(containers: PostgreSQLContainer): Unit =
+    Class.forName(driverName)
+    val ipAddress = containers.container.getHost
+    val port = containers.container.getMappedPort(5432)
+    ConnectionPool.singleton(containers.jdbcUrl, dbUserName, dbPassword)
+    Flyway.configure.dataSource(containers.jdbcUrl, dbUserName, dbPassword).load.migrate
+    given DB.CPContext = NoCPContext
+    given SettingsProvider = SettingsProvider.default
+}

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
@@ -1,0 +1,19 @@
+package fx
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import java.sql.SQLException
+import scalikejdbc._
+
+object DatabaseTests extends Properties("Database props"):
+
+  Class.forName("org.postgresql.Driver")
+  ConnectionPool.singleton("jdbc:postgresql://localhost:5432/scalafx", "postgres", "postgres")
+
+  property("Read only operation executes properly") = forAll { (s: String) =>
+    val names = DB.readOnlyWithControl  { implicit session =>
+      sql"select name from emp".map { rs => rs.string("name") }.list.apply()
+    }
+    structured(names.join.toEither.isRight)
+  }
+end DatabaseTests

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
@@ -3,7 +3,7 @@ package fx
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
 import java.sql.SQLException
-import scalikejdbc._
+import scalikejdbc.*
 
 object DatabaseTests extends Properties("Database props"):
 
@@ -14,6 +14,9 @@ object DatabaseTests extends Properties("Database props"):
     val names = DB.readOnlyWithControl  { implicit session =>
       sql"select name from emp".map { rs => rs.string("name") }.list.apply()
     }
-    structured(names.join.toEither.isRight)
+    run(structured(names.join.toEither.isRight)) match {
+      case b: Boolean => b
+      case _ => false
+    }
   }
 end DatabaseTests

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
@@ -25,9 +25,28 @@ class DatabaseTests extends ScalaFXSuite {
 
   testFX("Read only shift when tries to execute a non-read only operation") {
     val names: Database[Int] = DB.readOnlyWithControl { implicit session =>
-      sql"update emp set name = 'Abc' where id = 1".update.apply()
+      sql"update emp set name = 'Never changed in a readonly operation' where id = 1".update.apply()
     }
     assertFX(run(structured(names.join.toEither.isLeft)) match {
+      case b: Boolean => false
+      case _ => true
+    })
+  }
+
+  testFX("Transaction goes well after updating 2 rows.") {
+    val count: Transaction[Int] = DB.localTransaction { implicit session =>
+      sql"update emp set name = 'Abc' where id = 1".update.apply()
+      sql"update emp set name = 'Emp' where id = 2".update.apply()
+    }
+    assertEqualsFX(run(structured(count.join)), 1)
+  }
+
+  testFX("Transaction goes wrong and rollback after second update raise an exception") {
+    val count: Transaction[Int] = DB.localTransaction { implicit session =>
+      sql"update emp set name = 'Never changed in a failed transaction' where id = 1".update.apply()
+      sql"update emp set name = 'Empty' where inventing_row = 0".update.apply()
+    }
+    assertFX(run(structured(count.join.toEither.isLeft)) match {
       case b: Boolean => false
       case _ => true
     })

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
@@ -4,6 +4,7 @@ import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
 import java.sql.SQLException
 import scalikejdbc.*
+import scalikejdbc.DB.*
 
 object DatabaseTests extends Properties("Database props"):
 
@@ -11,12 +12,30 @@ object DatabaseTests extends Properties("Database props"):
   ConnectionPool.singleton("jdbc:postgresql://localhost:5432/scalafx", "postgres", "postgres")
 
   property("Read only operation executes properly") = forAll { (s: String) =>
-    val names = DB.readOnlyWithControl  { implicit session =>
+
+    given DB.CPContext = NoCPContext
+    given SettingsProvider = SettingsProvider.default
+
+    val names: Database[List[String]] = DB.readOnlyWithControl  { implicit session =>
       sql"select name from emp".map { rs => rs.string("name") }.list.apply()
     }
     run(structured(names.join.toEither.isRight)) match {
       case b: Boolean => b
       case _ => false
+    }
+  }
+
+  property("Read only shift when tries to execute a non-read only operation") = forAll { (s: String) =>
+
+    given DB.CPContext = NoCPContext
+    given SettingsProvider = SettingsProvider.default
+
+    val names: Database[Int] = DB.readOnlyWithControl  { implicit session =>
+      sql"update emp set name = ${s} where id = 1".update.apply()
+    }
+    run(structured(names.join.toEither.isLeft)) match {
+      case b: Boolean => false
+      case _ => true
     }
   }
 end DatabaseTests

--- a/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
+++ b/scalike-jdbc-scala-fx/src/test/scala/fx/DatabaseTests.scala
@@ -1,41 +1,35 @@
 package fx
 
-import org.scalacheck.Properties
-import org.scalacheck.Prop.forAll
+import munit.fx.ScalaFXSuite
 import java.sql.SQLException
 import scalikejdbc.*
 import scalikejdbc.DB.*
 
-object DatabaseTests extends Properties("Database props"):
+class DatabaseTests extends ScalaFXSuite {
 
   Class.forName("org.postgresql.Driver")
   ConnectionPool.singleton("jdbc:postgresql://localhost:5432/scalafx", "postgres", "postgres")
 
-  property("Read only operation executes properly") = forAll { (s: String) =>
+  given DB.CPContext = NoCPContext
+  given SettingsProvider = SettingsProvider.default
 
-    given DB.CPContext = NoCPContext
-    given SettingsProvider = SettingsProvider.default
-
-    val names: Database[List[String]] = DB.readOnlyWithControl  { implicit session =>
+  testFX("Read only operation executes properly") {
+    val names: Database[List[String]] = DB.readOnlyWithControl { implicit session =>
       sql"select name from emp".map { rs => rs.string("name") }.list.apply()
     }
-    run(structured(names.join.toEither.isRight)) match {
+    assertFX(run(structured(names.join.toEither.isRight)) match {
       case b: Boolean => b
       case _ => false
-    }
+    })
   }
 
-  property("Read only shift when tries to execute a non-read only operation") = forAll { (s: String) =>
-
-    given DB.CPContext = NoCPContext
-    given SettingsProvider = SettingsProvider.default
-
-    val names: Database[Int] = DB.readOnlyWithControl  { implicit session =>
-      sql"update emp set name = ${s} where id = 1".update.apply()
+  testFX("Read only shift when tries to execute a non-read only operation") {
+    val names: Database[Int] = DB.readOnlyWithControl { implicit session =>
+      sql"update emp set name = 'Abc' where id = 1".update.apply()
     }
-    run(structured(names.join.toEither.isLeft)) match {
+    assertFX(run(structured(names.join.toEither.isLeft)) match {
       case b: Boolean => false
       case _ => true
-    }
+    })
   }
-end DatabaseTests
+}


### PR DESCRIPTION
This PR adds a new submodule for supporting jdbc using the capabilities from Scala-FX, like Control and Loom virtual threads fibers automatically yield on blocking IO calls.

Implements:
- ReadOnly operations
- LocalTransactions operations

This PR aims for the following properties:

Given I have a postgres database
And I write a program in scala-fx
When I run a query in DBReadOnly
Then my read only query runs in a db transaction and returns deserialized data correctly.

Given I have a postgres database
And I write a program in scala-fx
When I run a non-read-only query in ReadOnlyDBTransaction effect context
Then my query should fail and shift control to Errors[TransactionException].

Given I have a postgres database
And I write a program in scala-fx
When I run a set of operations including database queries in a LocalTransaction effect
And the database returns an error
Then the database state should roll back to before when the transaction occurred.

Given I have a postgres database
And I write a program in scala-fx
When I run a set of operations including database queries in a LocalTransaction effect
And the program shifts control to the Errors effect
Then the database state should roll back to before when the transaction occured.

Given I have a postgres database
And I write a program in scala-fx
When I run a set of operations including database queries in a LocalTransaction effect
And the database calls and program calls within the transaction succeeds
Then I should return the return type for the block and exit the transaction.

Given I have a postgres database
And I write a program in scala-fx
When I run a set of operations in any Transaction type
Then the rest of the independent scala FX code on structured threads should continue to run without being blocked by the library's blocking IO. 