### PR TITLE
Iteration over the MUnit integration

### DIFF
--- a/munit-scalafx/src/it/scala/example/ScalaFXSuiteIntegrationTest.scala
+++ b/munit-scalafx/src/it/scala/example/ScalaFXSuiteIntegrationTest.scala
@@ -4,12 +4,33 @@ import fx.*
 import munit.fx.ScalaFXSuite
 
 class ScalaFXSuiteIntegrationSuite extends ScalaFXSuite:
+  def myFunction(
+      value1: Either[String, Int],
+      value2: Option[Int]): Errors[String | None.type] ?=> Int =
+    value1.bind + value2.bind
+
+  testFX("The computation's result satisfies the assertion") {
+    assertFX(myFunction(Right(1), Option(2)) == 3)
+  }
+
+  testFX("The computation's result doesn't satisfy the assertion".fail) {
+    assertFX(myFunction(Right(1), Option(2)) == 0)
+  }
+
+  testFX("The computation is short circuited with a None".fail) {
+    assertFX(myFunction(Right(1), None) == 1)
+  }
+
+  testFX("The computation is short circuited with a Left".fail) {
+    assertFX(myFunction(Left("BOOM!"), Option(2)) == 2)
+  }
+
   testFX("Example 1".fail) {
     assertFX(false)
   }
   testFX("Example 2") {
     val x: Console ?=> Unit = "example 1".writeLine()
-    val y: Console ?=> Unit = "example2".writeLine()
+    val y: Console ?=> Unit = "example 2".writeLine()
     structured(
       parallel(
         () => {

--- a/munit-scalafx/src/main/scala/munit/fx/Asserts.scala
+++ b/munit-scalafx/src/main/scala/munit/fx/Asserts.scala
@@ -4,7 +4,7 @@ package fx
 import scala.annotation.implicitNotFound
 
 /**
- * The Asserts copability Models assertion error-handling capabilities.
+ * The Asserts capability models assertion error-handling capabilities.
  *
  * AssertionError falls outside the hierarchy covered by the Throws capability,
  * @tparam R
@@ -14,8 +14,8 @@ import scala.annotation.implicitNotFound
   "Missing capability:\n" +
     "* Asserts[${R}]\n" +
     "alternatively you may resolve this call with \n" +
-    "```scala\nhandle(f)(recover)\n```\n" +
-    "or\n ignore thrown exceptions with import munit.fx.unsafe.unsafeAssertions`")
+    "```scala\nhandleAssert(f)(recover)\n```\n" +
+    "or\n ignore thrown exceptions with import munit.fx.Asserts.unsafeAsserts")
 opaque type Asserts[-R <: AssertionError] = Unit
 
 object Asserts {
@@ -24,7 +24,7 @@ object Asserts {
    * Importable capability evidence that allows unsafely throwing assertion errors when
    * imported.
    * @tparam R
-   *   The assertion error subtype that is allowod to be thrown.
+   *   The assertion error subtype that is allowed to be thrown.
    */
   given unsafeAsserts[R <: AssertionError]: Asserts[R] = ()
 }
@@ -43,7 +43,7 @@ object Asserts {
  */
 inline def handleAssert[R <: AssertionError, A](
     inline f: Asserts[R] ?=> A
-)(inline recover: (R) => A): A =
+)(inline recover: R => A): A =
   try
     import munit.fx.Asserts.unsafeAsserts
     f

--- a/munit-scalafx/src/main/scala/munit/fx/ScalaFxAssertions.scala
+++ b/munit-scalafx/src/main/scala/munit/fx/ScalaFxAssertions.scala
@@ -39,11 +39,11 @@ trait ScalaFxAssertions:
    * @see
    *   [munit.Clue]
    */
-  def assertEqualsFX[A, B](
-      obtained: A,
+  def assertEqualsFX[R, A, B](
+      obtained: Errors[R] ?=> A,
       expected: B,
       clue: => Any = "values are not the same"
-  ): Location ?=> B <:< A ?=> Errors[AssertionError] ?=> Unit =
+  ): Location ?=> B <:< A ?=> (Errors[AssertionError], Errors[R]) ?=> Unit =
     liftToFX(assertEquals(obtained, expected, clue))
 
   /**
@@ -56,8 +56,8 @@ trait ScalaFxAssertions:
    * @see
    *   [munit.Clue]
    */
-  def assumeFX(cond: => Boolean, clue: => Any = "assumption failed")
-      : Location ?=> Errors[AssumptionViolatedException] ?=> Unit =
+  def assumeFX[R](cond: => Errors[R] ?=> Boolean, clue: => Any = "assumption failed")
+      : Location ?=> (Errors[AssumptionViolatedException], Errors[R]) ?=> Unit =
     try assume(cond, clue)
     catch case ex: AssumptionViolatedException => ex.raise
 
@@ -72,10 +72,11 @@ trait ScalaFxAssertions:
    * @see
    *   [munit.Clue]
    */
-  def assertNoDiffFX(
-      obtained: String,
+  def assertNoDiffFX[R](
+      obtained: Errors[R] ?=> String,
       expected: String,
-      clue: => Any = "diff assertion failed"): Location ?=> Errors[AssertionError] ?=> Unit =
+      clue: => Any = "diff assertion failed")
+      : Location ?=> (Errors[AssertionError], Errors[R]) ?=> Unit =
     liftToFX(assertNoDiff(obtained, expected, clue))
 
   /**
@@ -93,11 +94,11 @@ trait ScalaFxAssertions:
    * @see
    *   [munit.Clue]
    */
-  def assertNotEqualsFX[A, B](
-      obtained: A,
+  def assertNotEqualsFX[R, A, B](
+      obtained: Errors[R] ?=> A,
       expected: B,
       clue: => Any = "values are the same"
-  ): Location ?=> A =:= B ?=> Errors[AssertionError] ?=> Unit =
+  ): Location ?=> A =:= B ?=> (Errors[AssertionError], Errors[R]) ?=> Unit =
     liftToFX(assertNotEquals(obtained, expected, clue))
 
   /**
@@ -113,12 +114,12 @@ trait ScalaFxAssertions:
    * @see
    *   [munit.Clue]
    */
-  def assertEqualsDoubleFX(
-      obtained: Double,
+  def assertEqualsDoubleFX[R](
+      obtained: Errors[R] ?=> Double,
       expected: Double,
       delta: Double,
       clue: => Any = "values are not the same"
-  ): Location ?=> Errors[AssertionError] ?=> Unit = liftToFX(
+  ): Location ?=> (Errors[AssertionError], Errors[R]) ?=> Unit = liftToFX(
     assertEqualsDouble(obtained, expected, delta, clue))
 
   /**
@@ -134,12 +135,12 @@ trait ScalaFxAssertions:
    * @see
    *   munit.Clue
    */
-  def assertEqualsFloatFX(
-      obtained: Float,
+  def assertEqualsFloatFX[R](
+      obtained: Errors[R] ?=> Float,
       expected: Float,
       delta: Float,
       clue: => Any = "values are not the same"
-  ): Location ?=> Errors[AssertionError] ?=> Unit = liftToFX(
+  ): Location ?=> (Errors[AssertionError], Errors[R]) ?=> Unit = liftToFX(
     assertEqualsFloat(obtained, expected, delta, clue))
 
   private def liftToFX[A](

--- a/munit-scalafx/src/main/scala/munit/fx/ScalaFxAssertions.scala
+++ b/munit-scalafx/src/main/scala/munit/fx/ScalaFxAssertions.scala
@@ -20,9 +20,8 @@ trait ScalaFxAssertions:
    * @see
    *   [munit.Clue]
    */
-  def assertFX(
-      cond: => Boolean,
-      clue: => Any = "assertion failed"): Location ?=> Errors[AssertionError] ?=> Unit =
+  def assertFX[R](cond: => Errors[R] ?=> Boolean, clue: => Any = "assertion failed")
+      : Location ?=> (Errors[AssertionError], Errors[R]) ?=> Unit =
     liftToFX(assert(cond, clue))
 
   /**


### PR DESCRIPTION
So far,  as part of the MUnit integration into the encoding proposed in this project, @jackcviers presented a design that caught the exception thrown by the assertion methods when the condition wasn't satisfied. The exception was then safely handled using the Control capability to short-circuit the computation.

However, that design didn't cover the case where we want to test a computation that might fail with an error that doesn't extend Throwable. For example, this test would compile:
```
def myFunction(value1: Either[Throwable, Int], value2: Int): Errors[Throwable] ?=> Int =
  value1.bind + value2

testFX("The computation's result satisfies the assertion") {
  assertFX(myFunction(Left(Throwable("BOOM!")), 2) == 3)
}
```
but not this one:
```
def myFunction(value1: Either[String, Int], value2: Int): Errors[String] ?=> Int =
  value1.bind + value2

testFX("The computation's result satisfies the assertion") {
  assertFX(myFunction(Left("BOOM!"), 2) == 3)
}
```

This pull request proposes changes that will allow us to test computations that might short-circuit with a non-Throwable error.