### PR TITLE
Write bracket tests

### DIFF
--- a/scala-fx/src/main/scala/fx/Fiber.scala
+++ b/scala-fx/src/main/scala/fx/Fiber.scala
@@ -2,6 +2,7 @@ package fx
 
 import java.util.concurrent.Future
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 
 opaque type Fiber[A] = Future[A]
 
@@ -20,7 +21,9 @@ def uncancellable[A](fn: () => A): A = {
         case t: Throwable =>
           promise.completeExceptionally(t)
     })
-  promise.join
+  try
+    promise.join
+  catch case e : CompletionException => throw e.getCause
 }
 
 def fork[B](f: () => B)(using structured: Structured): Fiber[B] =

--- a/scala-fx/src/test/scala/fx/BracketTests.scala
+++ b/scala-fx/src/test/scala/fx/BracketTests.scala
@@ -1,0 +1,60 @@
+package fx
+
+import fx.ResourcesTests.property
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+
+import java.util.concurrent.{CompletableFuture, CompletionException}
+
+object BracketTests extends Properties("Bracket Tests"):
+
+  property("bracketCase identity") = forAll { (n: Int) =>
+    bracketCase(() => n, identity, (_, _) => ()) == n
+  }
+
+  case class CustomEx(val token: String) extends RuntimeException
+
+  property("bracketCase exception identity") = forAll { (msg: String) =>
+    val res =
+      try
+        bracketCase(() => throw CustomEx(msg), _ => throw RuntimeException("Cannot come here"), (_, _) => ())
+      catch case CustomEx(msg) => msg
+
+    res == msg
+  }
+
+  property("bracketCase must run release task on use error") = forAll { (msg: String) =>
+    val promise = new CompletableFuture[ExitCase]
+    val res =
+      try
+        bracketCase(() => (), _ => throw CustomEx(msg), (_, ex) => promise.complete(ex))
+      catch case CustomEx(msg) => msg
+
+    res == msg && promise.join() == ExitCase.Failure(CustomEx(msg))
+  }
+
+  property("bracketCase must run release task on use success") = forAll { (msg: String) =>
+    val promise = new CompletableFuture[ExitCase]
+    val res = bracketCase(() => (), _ => msg, (_, ex) => promise.complete(ex))
+
+    res == msg && promise.join() == ExitCase.Completed
+  }
+
+  property("bracketCase cancellation in use") = forAll { (msg: String) =>
+    throw RuntimeException("I am hanging.")
+    
+    val latch = new CompletableFuture[Unit]
+    val promise = new CompletableFuture[ExitCase]
+    structured {
+      val fiber = fork(() => bracketCase(() => (), _ => {
+        latch.complete(())
+        Thread.sleep(100_000)
+      }, (_,ex) => promise.complete(ex)))
+      latch.join()
+      fiber.cancel()
+      promise.join().isInstanceOf[ExitCase.Cancelled]
+    }
+  }
+
+end BracketTests
+

--- a/scala-fx/src/test/scala/fx/UncancellableTests.scala
+++ b/scala-fx/src/test/scala/fx/UncancellableTests.scala
@@ -1,0 +1,50 @@
+package fx
+
+import fx.ResourcesTests.property
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+
+import java.util.concurrent.{CompletableFuture, CompletionException}
+
+object UncancellableTests extends Properties("Bracket Tests"):
+
+  property("uncancellable identity") = forAll { (n: Int) =>
+    uncancellable(() => n) == n
+  }
+
+  case class CustomEx(val token: String) extends RuntimeException
+
+  property("uncancellable exception identity") = forAll { (msg: String) =>
+    val res =
+      try
+        uncancellable(() => throw CustomEx(msg))
+      catch case CustomEx(msg) => msg
+
+    res == msg
+  }
+
+//  "Uncancellable back pressures withTimeoutOrNull" {
+//    runBlockingTest {
+//      checkAll(Arb.long(50, 100), Arb.long(300, 400)) {
+//        a
+//        , b ->
+//        val start = currentTime
+//
+//        val n = withTimeoutOrNull(a.milliseconds) {
+//          uncancellable {
+//            delay(b.milliseconds)
+//          }
+//        }
+//
+//        val duration = currentTime - start
+//
+//        n shouldBe null // timed-out so should be null
+//        require((duration) >= b) {
+//          "Should've taken longer than $b milliseconds, but took $duration"
+//        }
+//      }
+//    }
+//  }
+
+end UncancellableTests
+


### PR DESCRIPTION
- `bracketCase cancellation in use` is hanging, and could explain why the laws are hanging. (Didn't have time to investigate further).
- `uncancellable` was not correctly unwrapping its exception, and this could result in `CancellationException` not correctly propagating since it gets wrapped. This could also explain some issues.

