### PR TITLE
Plugin: Convert simple suspended def with no parameters and a suspendCoroutine

### DIFF
--- a/continuationsPlugin/src/main/java/continuations/SafeContinuationBase.java
+++ b/continuationsPlugin/src/main/java/continuations/SafeContinuationBase.java
@@ -1,0 +1,26 @@
+package continuations;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/*
+ * `AtomicReferenceFieldUpdater` cannot be used in Scala currently,
+ * see https://contributors.scala-lang.org/t/pre-sip-support-java-util-concurrent-atomic-atomic-fieldupdaters/5287.
+ *
+ * For this pattern
+ * see https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/concurrent/TrieMap.scala#L520 (`CNode`)
+ * and https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/concurrent/CNodeBase.java#L17.
+ */
+abstract class SafeContinuationBase {
+    @SuppressWarnings("unchecked")
+    static final AtomicReferenceFieldUpdater<SafeContinuationBase, Object>  updater =
+        AtomicReferenceFieldUpdater.newUpdater(
+                (Class<SafeContinuationBase>) (Class<?>) SafeContinuationBase.class,
+                (Class<Object>) (Class<?>) Object.class,
+                "result");
+
+    volatile Object result = null;
+
+    boolean CAS_RESULT(Object oldval, Object nval) {
+        return updater.compareAndSet(this, oldval, nval);
+    }
+}

--- a/continuationsPlugin/src/main/scala/continuations/Continuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Continuation.scala
@@ -16,7 +16,7 @@ object Continuation:
   /**
    * No body needed as the compiler plugin replaces this in call sites
    */
-  inline def suspendContinuation[A](f: Continuation[A] => Unit)(using s: Suspend): A =
+  def suspendContinuation[A](f: Continuation[A] => Unit)(using s: Suspend): A =
     ???
 
 abstract class RestrictedContinuation(

--- a/continuationsPlugin/src/main/scala/continuations/Continuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Continuation.scala
@@ -13,6 +13,12 @@ object Continuation:
   enum State:
     case Suspended, Undecided, Resumed
 
+  /**
+   * No body needed as the compiler plugin replaces this in call sites
+   */
+  inline def suspendContinuation[A](f: Continuation[A] => Unit)(using s: Suspend): A =
+    ???
+
 abstract class RestrictedContinuation(
     completion: Continuation[Any | Null] | Null
 ) extends BaseContinuationImpl(completion):

--- a/continuationsPlugin/src/main/scala/continuations/Continuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Continuation.scala
@@ -16,7 +16,7 @@ object Continuation:
   /**
    * No body needed as the compiler plugin replaces this in call sites
    */
-  def suspendContinuation[A](f: Continuation[A] => Unit)(using s: Suspend): A =
+  inline def suspendContinuation[A](f: Continuation[A] => Unit)(using s: Suspend): A =
     ???
 
 abstract class RestrictedContinuation(

--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -1,15 +1,15 @@
 package continuations
 
 import dotty.tools.dotc.ast.Trees.*
-import dotty.tools.dotc.ast.{tpd, Trees}
+import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.{ctx, Context}
 import dotty.tools.dotc.core.Decorators.*
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.StdNames.*
-import dotty.tools.dotc.core.Symbols.{Symbol, TermSymbol, *}
-import dotty.tools.dotc.core.Types.{AppliedType, OrType, Type}
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Types.{AppliedType, Type}
 import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
 import dotty.tools.dotc.report
 import dotty.tools.dotc.transform.{PickleQuotes, Staging}
@@ -50,24 +50,19 @@ class ContinuationsPhase extends PluginPhase:
     report.logWith("transformBlock")(tree.show)
     tree
 
-  var continuationTraitSym: ClassSymbol = _
-  var continuationObjectSym: Symbol = _
-  var safeContinuationClassSym: ClassSymbol = _
-  var interceptedMethodSym: TermSymbol = _
+  var defDefTransforms: DefDefTransforms = _
 
-  override def prepareForUnit(tree: Tree)(using Context): Context =
-    continuationTraitSym = requiredClass("continuations.Continuation")
-    continuationObjectSym = continuationTraitSym.companionModule
-
-    safeContinuationClassSym = requiredClass("continuations.SafeContinuation")
-
-    interceptedMethodSym =
+  override def prepareForDefDef(tree: DefDef)(using Context): Context =
+    defDefTransforms = new DefDefTransforms(
+      requiredClass("continuations.Continuation"),
+      requiredClass("continuations.SafeContinuation"),
       requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
+    )
 
     ctx
 
   override def transformDefDef(tree: DefDef)(using Context): Tree =
-    transformSuspendNoParametersOneContinuationResume(tree)
+    defDefTransforms.transformSuspendContinuation(tree)
 
   @tailrec final def transformStatements(
       block: Block,
@@ -95,153 +90,3 @@ class ContinuationsPhase extends PluginPhase:
     tree match
       case Apply(_, _) => returnsContextFunctionWithSuspendType(tree)
       case _ => false
-
-  def hasOnlySuspendParam(tree: DefDef)(using Context): Boolean =
-    tree.termParamss match
-      case List(Nil, param :: Nil) => isSuspendType(param.tpe)
-      case _ => false
-
-  def getAllSubTrees(tree: Tree)(using Context): List[Tree] = {
-    val deepFolder: DeepFolder[ListBuffer[tpd.Tree]] =
-      new DeepFolder[ListBuffer[Tree]]((subTrees, tree) => subTrees += tree)
-
-    /*
-     * Needed for the `case Inlined(...)` because `DeepFolder.apply(...).foldOver` for the `Inlined` case  doesn't use
-     * the `call` tree and as a result the `Inlined` is not being unwrapped.
-     */
-    @tailrec
-    def recurse(trees: List[Tree], buf: ListBuffer[Tree]): List[Tree] =
-      trees match
-        case Nil =>
-          buf.toList
-        case Inlined(call, _, _) :: rest =>
-          recurse(call :: rest, buf)
-        case t :: rest =>
-          val (inlined, notInlined) =
-            deepFolder.apply(ListBuffer[Tree](), t).partition {
-              case _: Inlined => true
-              case _ => false
-            }
-          recurse(inlined.toList ++ rest, notInlined ++ buf)
-
-    recurse(tree.toList, ListBuffer[Tree]())
-  }
-
-  /*
-   * It works with only one top level `suspendContinuation` that just calls `resume`
-   * and it replaces the parent method body keeping any rows before the `suspendContinuation` (but not ones after).
-   */
-  def transformSuspendNoParametersOneContinuationResume(tree: DefDef)(using Context): Tree = {
-    if (hasOnlySuspendParam(tree)) {
-      val suspendContinuationName = "continuations.Continuation.suspendContinuation"
-      val resumeName = "continuations.Continuation.resume"
-
-      val suspendContinuationResumeCall: List[Tree] =
-        getAllSubTrees(tree.rhs)
-          .collect {
-            case Apply(TypeApply(fun, _), List(arg))
-                if fun.symbol.showFullName == suspendContinuationName =>
-              arg
-          }
-          .flatMap(getAllSubTrees)
-          .collect {
-            case Apply(fun, List(arg)) if fun.symbol.showFullName == resumeName =>
-              arg
-          }
-
-      if (suspendContinuationResumeCall.size == 1) {
-        val parent: Symbol = tree.symbol
-        val returnType: Type = tree.tpt.tpe
-        val resumeInput = suspendContinuationResumeCall.head
-
-        val rowsBeforeSuspend =
-          tree.rhs match
-            case Block(trees, _) =>
-              trees
-                .map {
-                  case Inlined(c, _, _) => c
-                  case t => t
-                }
-                .takeWhile(_.symbol.showFullName != suspendContinuationName)
-            case _ => List.empty[Tree]
-
-        val continuationTyped: Type =
-          continuationTraitSym.typeRef.appliedTo(returnType)
-
-        val completion =
-          newSymbol(parent, termName("completion"), Flags.LocalParam, continuationTyped)
-
-        val continuation1: ValDef =
-          ValDef(
-            newSymbol(parent, termName("continuation1"), Flags.Local, continuationTyped),
-            ref(completion))
-
-        val undecidedState =
-          ref(continuationObjectSym).select(termName("State")).select(termName("Undecided"))
-
-        val interceptedCall =
-          ref(interceptedMethodSym)
-            .appliedToType(returnType)
-            .appliedTo(ref(continuation1.symbol))
-            .appliedToNone
-
-        val safeContinuationConstructor =
-          New(ref(safeContinuationClassSym))
-            .select(nme.CONSTRUCTOR)
-            .appliedToType(returnType)
-            .appliedTo(interceptedCall, undecidedState)
-
-        val safeContinuation: ValDef =
-          ValDef(
-            newSymbol(
-              parent,
-              termName("safeContinuation"),
-              Flags.Local,
-              safeContinuationConstructor.tpe),
-            safeContinuationConstructor)
-
-        val safeContinuationRef =
-          ref(safeContinuation.symbol)
-
-        val suspendContinuation: ValDef =
-          ValDef(
-            newSymbol(
-              parent,
-              termName("suspendContinuation"),
-              Flags.Local,
-              ctx.definitions.IntType),
-            Literal(Constant(0))
-          )
-
-        val suspendContinuationResume =
-          safeContinuationRef.select(termName("resume")).appliedTo(resumeInput)
-
-        val suspendContinuationGetThrow =
-          safeContinuationRef.select(termName("getOrThrow")).appliedToNone
-
-        val body = Block(
-          rowsBeforeSuspend ++
-            (continuation1 :: safeContinuation :: suspendContinuation :: suspendContinuationResume :: Nil),
-          suspendContinuationGetThrow
-        )
-
-        val suspendedState =
-          ref(continuationObjectSym).select(termName("State")).select(termName("Suspended"))
-
-        /* TODO:
-         * Do we need to handle and remove `Continuation.State.Suspended.type` from this return type?
-         *
-         * If `Suspended` is actually being returned without being handled it will result to a `ClassCastException` as
-         * in runtime we have a method which expects a value that is of `returnType`.
-         */
-        // Any | Null | Continuation.State.Suspended.type
-        val finalMethodReturnType =
-          OrType(
-            OrType(ctx.definitions.AnyType, ctx.definitions.NullType, soft = false),
-            suspendedState.symbol.namedType,
-            soft = false)
-
-        DefDef(parent.asTerm, List(List(completion)), finalMethodReturnType, body)
-      } else tree
-    } else tree
-  }

--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -50,19 +50,8 @@ class ContinuationsPhase extends PluginPhase:
     report.logWith("transformBlock")(tree.show)
     tree
 
-  var defDefTransforms: DefDefTransforms = _
-
-  override def prepareForDefDef(tree: DefDef)(using Context): Context =
-    defDefTransforms = new DefDefTransforms(
-      requiredClass("continuations.Continuation"),
-      requiredClass("continuations.SafeContinuation"),
-      requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
-    )
-
-    ctx
-
   override def transformDefDef(tree: DefDef)(using Context): Tree =
-    defDefTransforms.transformSuspendContinuation(tree)
+    new DefDefTransforms().transformSuspendContinuation(tree)
 
   @tailrec final def transformStatements(
       block: Block,

--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -1,16 +1,17 @@
 package continuations
 
-import dotty.tools.dotc.report
 import dotty.tools.dotc.ast.Trees.*
-import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.{tpd, Trees}
 import dotty.tools.dotc.core.Constants.Constant
-import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Contexts.{ctx, Context}
 import dotty.tools.dotc.core.Decorators.*
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.StdNames.*
-import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Symbols.{Symbol, TermSymbol, *}
 import dotty.tools.dotc.core.Types.{AppliedType, Type}
 import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
-import dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.TypeRef
+import dotty.tools.dotc.report
 import dotty.tools.dotc.transform.{PickleQuotes, Staging}
 
 import scala.annotation.tailrec
@@ -47,6 +48,129 @@ class ContinuationsPhase extends PluginPhase:
     report.logWith("transformBlock")(tree)
     report.logWith("transformBlock")(tree.show)
     tree
+
+  var continuationTraitSym: ClassSymbol = _
+  var continuationObjectSym: TermSymbol = _
+  var safeContinuationClassApplySym: TermSymbol = _
+  var interceptedMethodSym: TermSymbol = _
+
+  override def prepareForUnit(tree: Tree)(using Context): Context =
+    continuationTraitSym = requiredClass("continuations.Continuation")
+    continuationObjectSym = requiredModule("continuations.Continuation")
+
+    safeContinuationClassApplySym = requiredModule("continuations.SafeContinuation")
+      .requiredMethod("apply", List(defn.AnyType, defn.AnyType))
+
+    interceptedMethodSym =
+      requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
+
+    ctx
+
+  override def transformDefDef(tree: DefDef)(using Context): Tree = {
+    val (input, callsSuspendContinuation): (Tree, Boolean) =
+      tree.rhs match
+        case Inlined(
+              Apply(
+                Apply(
+                  fun1,
+                  List(
+                    Block(
+                      Nil,
+                      Block(List(DefDef(_, _, _, Block(Nil, Apply(fun2, List(arg))))), _)))),
+                List(_)),
+              Nil,
+              _) =>
+          (
+            arg,
+            fun1.symbol.showFullName == "continuations.Continuation.suspendContinuation" &&
+              fun2.symbol.showFullName == "continuations.Continuation.resume"
+          )
+        case _ =>
+          (EmptyTree, false)
+
+    tree.termParamss match
+      case List(Nil, usingSuspend :: Nil)
+          if isSuspendType(usingSuspend.tpe) && callsSuspendContinuation =>
+        val parent: Symbol = tree.symbol
+        val returnType: Trees.Tree[Type] = tree.tpt
+
+        // Continuation[Int]
+        val continuationTyped: AppliedTypeTree =
+          AppliedTypeTree(ref(continuationTraitSym), List(returnType))
+
+        // (completion: continuations.Continuation[Int])
+        val completion =
+          newSymbol(parent, termName("completion"), Flags.LocalParam, continuationTyped.tpe)
+
+        // val continuation1: continuations.Continuation = completion
+        val continuation1: ValDef =
+          ValDef(
+            newSymbol(parent, termName("continuation1"), Flags.Local, continuationTyped.tpe),
+            ref(completion))
+
+        // Continuation.State.Undecided
+        val undecided =
+          ref(continuationObjectSym).select(termName("State")).select(termName("Undecided"))
+
+        // continuation1.intercepted()
+        def interceptedCall =
+          ref(interceptedMethodSym)
+            .appliedToType(returnType.tpe)
+            .appliedTo(ref(continuation1.symbol))
+            .appliedToNone
+
+        // SafeContinuation(continuation1.intercepted(), Continuation.State.Undecided)
+        // TODO: how to call it with `new`, is this why it fails?
+        val safeContinuationConstructor =
+          ref(safeContinuationClassApplySym)
+            .appliedToType(returnType.tpe)
+            .appliedTo(interceptedCall, undecided)
+
+        // val safeContinuation: SafeContinuation[Int] = SafeContinuation(continuation1.intercepted(), Continuation.State.Undecided)
+        val safeContinuation: ValDef =
+          ValDef(
+            newSymbol(
+              parent,
+              termName("safeContinuation"),
+              Flags.Local,
+              safeContinuationConstructor.tpe),
+            safeContinuationConstructor)
+
+        // val suspendContinuation: Int = 0
+        // TODO: try decompile with foo: String, see if it is the same
+        val suspendContinuation: ValDef =
+          ValDef(
+            newSymbol(
+              parent,
+              termName("suspendContinuation"),
+              Flags.Local,
+              ctx.definitions.IntType),
+            Literal(Constant(0))
+          )
+
+        // safeContinuation.resume(Right(Int.box(1)))
+        // Int.box should happen from the 1st task in the ClickUp ticket
+        val suspendContinuationResume =
+          safeContinuation.tpt.select(termName("resume")).appliedTo(input)
+
+        // safeContinuation.getOrThrow()
+        val suspendContinuationGetThrow =
+          safeContinuation.tpt.select(termName("getOrThrow")).appliedToNone
+
+        val body = Block(
+          continuation1 :: safeContinuation :: suspendContinuation :: suspendContinuationResume :: Nil,
+          suspendContinuationGetThrow
+        )
+
+        val methodDef =
+          DefDef(parent.asTerm, List(List(completion)), ctx.definitions.AnyType, body)
+
+        println(s"PLUGIN ${methodDef.show}")
+
+        methodDef
+      case _ =>
+        tree
+  }
 
   @tailrec final def transformStatements(
       block: Block,

--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.core.Symbols.{Symbol, TermSymbol, *}
-import dotty.tools.dotc.core.Types.{AppliedType, Type}
+import dotty.tools.dotc.core.Types.{AppliedType, OrType, Type}
 import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
 import dotty.tools.dotc.report
 import dotty.tools.dotc.transform.{PickleQuotes, Staging}
@@ -51,16 +51,15 @@ class ContinuationsPhase extends PluginPhase:
     tree
 
   var continuationTraitSym: ClassSymbol = _
-  var continuationObjectSym: TermSymbol = _
-  var safeContinuationClassApplySym: TermSymbol = _
+  var continuationObjectSym: Symbol = _
+  var safeContinuationClassApplySym: ClassSymbol = _
   var interceptedMethodSym: TermSymbol = _
 
   override def prepareForUnit(tree: Tree)(using Context): Context =
     continuationTraitSym = requiredClass("continuations.Continuation")
-    continuationObjectSym = requiredModule("continuations.Continuation")
+    continuationObjectSym = continuationTraitSym.companionModule
 
-    safeContinuationClassApplySym = requiredModule("continuations.SafeContinuation")
-      .requiredMethod("apply", List(defn.AnyType, defn.AnyType))
+    safeContinuationClassApplySym = requiredClass("continuations.SafeContinuation")
 
     interceptedMethodSym =
       requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
@@ -129,15 +128,14 @@ class ContinuationsPhase extends PluginPhase:
   }
 
   /*
-   * For now it works with only one `suspendContinuation` that calls `resume` in the method body
+   * It works with only one `suspendContinuation` that calls `resume` in the method body
    * and it replaces the whole body
    */
   def transformSuspendNoParametersOneContinuationResume(tree: DefDef)(using Context): Tree = {
     if (hasOnlySuspendParam(tree)) {
-      val subTrees: List[Tree] = getAllSubTrees(tree.rhs)
 
       val suspendContinuationResumeCall: List[Tree] =
-        subTrees
+        getAllSubTrees(tree.rhs)
           .collect {
             case Apply(TypeApply(fun, _), List(arg))
                 if fun
@@ -176,20 +174,20 @@ class ContinuationsPhase extends PluginPhase:
           ref(continuationObjectSym).select(termName("State")).select(termName("Undecided"))
 
         // continuation1.intercepted()
-        def interceptedCall =
+        val interceptedCall =
           ref(interceptedMethodSym)
             .appliedToType(returnType.tpe)
             .appliedTo(ref(continuation1.symbol))
             .appliedToNone
 
-        // SafeContinuation(continuation1.intercepted(), Continuation.State.Undecided)
-        // TODO: how to call it with `new`, is this why it fails?
+        // new SafeContinuation(continuation1.intercepted(), Continuation.State.Undecided)
         val safeContinuationConstructor =
-          ref(safeContinuationClassApplySym)
+          New(ref(safeContinuationClassApplySym))
+            .select(nme.CONSTRUCTOR)
             .appliedToType(returnType.tpe)
             .appliedTo(interceptedCall, undecided)
 
-        // val safeContinuation: SafeContinuation[Int] = SafeContinuation(continuation1.intercepted(), Continuation.State.Undecided)
+        // val safeContinuation: SafeContinuation[Int] = new SafeContinuation(continuation1.intercepted(), Continuation.State.Undecided)
         val safeContinuation: ValDef =
           ValDef(
             newSymbol(
@@ -199,8 +197,10 @@ class ContinuationsPhase extends PluginPhase:
               safeContinuationConstructor.tpe),
             safeContinuationConstructor)
 
+        val safeContinuationRef: Tree =
+          ref(safeContinuation.symbol)
+
         // val suspendContinuation: Int = 0
-        // TODO: try decompile with foo: String, see if it is the same
         val suspendContinuation: ValDef =
           ValDef(
             newSymbol(
@@ -214,19 +214,35 @@ class ContinuationsPhase extends PluginPhase:
         // safeContinuation.resume(Right(Int.box(1)))
         // Int.box should happen from the 1st task in the ClickUp ticket
         val suspendContinuationResume =
-          safeContinuation.tpt.select(termName("resume")).appliedTo(resumeInput)
+          safeContinuationRef.select(termName("resume")).appliedTo(resumeInput)
 
         // safeContinuation.getOrThrow()
         val suspendContinuationGetThrow =
-          safeContinuation.tpt.select(termName("getOrThrow")).appliedToNone
+          safeContinuationRef.select(termName("getOrThrow")).appliedToNone
 
         val body = Block(
           continuation1 :: safeContinuation :: suspendContinuation :: suspendContinuationResume :: Nil,
           suspendContinuationGetThrow
         )
 
+        // Continuation.State.Suspended
+        val suspended: Tree =
+          ref(continuationObjectSym).select(termName("State")).select(termName("Suspended"))
+
+        /* TODO:
+         * Probably we want to remove `Continuation.State.Suspended.type` from this return type
+         * It should be handled in some way in here or in SafeContinuation so the return will be either `throw` or
+         * a result value of the correct/expected parent type (now we get a ClassCastException if it is `Suspended`)
+         */
+        // Any | Null | Continuation.State.Suspended.type
+        val methodReturnType =
+          OrType(
+            OrType(ctx.definitions.AnyType, ctx.definitions.NullType, soft = false),
+            suspended.symbol.namedType,
+            soft = false)
+
         val methodDef =
-          DefDef(parent.asTerm, List(List(completion)), ctx.definitions.AnyType, body)
+          DefDef(parent.asTerm, List(List(completion)), methodReturnType, body)
 
         println(s"PLUGIN ${methodDef.show}")
 

--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -106,8 +106,8 @@ class ContinuationsPhase extends PluginPhase:
       new DeepFolder[ListBuffer[Tree]]((subTrees, tree) => subTrees += tree)
 
     /*
-     * Needed for the `case Inlined(...)` because `DeepFolder.apply(...).foldOver` for the `Inlined` doesn't use
-     * the `call` tree so the `Inlined` is not being unwrapped (???)
+     * Needed for the `case Inlined(...)` because `DeepFolder.apply(...).foldOver` for the `Inlined` case  doesn't use
+     * the `call` tree and as a result the `Inlined` is not being unwrapped.
      */
     @tailrec
     def recurse(trees: List[Tree], buf: ListBuffer[Tree]): List[Tree] =
@@ -218,9 +218,10 @@ class ContinuationsPhase extends PluginPhase:
           ref(continuationObjectSym).select(termName("State")).select(termName("Suspended"))
 
         /* TODO:
-         * Probably we want to remove `Continuation.State.Suspended.type` from this return type.
-         * It should be handled in some way in here or in SafeContinuation so the return will be either `throw` or
-         * a result value of the correct/expected parent type (now we get a ClassCastException if it is `Suspended`)
+         * Do we need to handle and remove `Continuation.State.Suspended.type` from this return type?
+         *
+         * If `Suspended` is actually being returned without being handled it will result to a `ClassCastException` as
+         * in runtime we have a method which expects a value that is of `returnType`.
          */
         // Any | Null | Continuation.State.Suspended.type
         val finalMethodReturnType =

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -1,0 +1,161 @@
+package continuations
+
+import continuations.DefDefTransforms.*
+import dotty.tools.dotc.ast.Trees.*
+import dotty.tools.dotc.ast.tpd.TreeOps
+import dotty.tools.dotc.ast.{tpd, Trees}
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Contexts.{ctx, Context}
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.core.Names.termName
+import dotty.tools.dotc.core.StdNames.nme
+import dotty.tools.dotc.core.Symbols.{newSymbol, ClassSymbol, Symbol, TermSymbol}
+import dotty.tools.dotc.core.Types.{OrType, Type}
+
+import scala.annotation.tailrec
+import scala.collection.immutable.List
+import scala.collection.mutable.ListBuffer
+
+class DefDefTransforms(
+    continuationTraitSym: ClassSymbol,
+    safeContinuationClassSym: ClassSymbol,
+    interceptedMethodSym: TermSymbol
+)(using Context) {
+  import tpd.*
+
+  private val continuationObjectSym: Symbol = continuationTraitSym.companionModule
+
+  /*
+   * It works with only one top level `suspendContinuation` that just calls `resume`
+   * and it replaces the parent method body keeping any rows before the `suspendContinuation` (but not ones after).
+   */
+  private def transformSuspendNoParametersOneContinuationResume(
+      tree: DefDef,
+      resumeArg: Tree): DefDef =
+    val parent: Symbol = tree.symbol
+    val returnType: Type = tree.tpt.tpe
+
+    val rowsBeforeSuspend =
+      tree.rhs match
+        case Block(trees, expr) =>
+          (trees :+ expr).takeWhile(_.symbol.showFullName != suspendContinuationFullName)
+        case _ =>
+          List.empty[Tree]
+
+    val continuationTyped: Type =
+      continuationTraitSym.typeRef.appliedTo(returnType)
+
+    val completion =
+      newSymbol(parent, termName("completion"), Flags.LocalParam, continuationTyped)
+
+    val continuation1: ValDef =
+      ValDef(
+        newSymbol(parent, termName("continuation1"), Flags.Local, continuationTyped),
+        ref(completion))
+
+    val undecidedState =
+      ref(continuationObjectSym).select(termName("State")).select(termName("Undecided"))
+
+    val interceptedCall =
+      ref(interceptedMethodSym)
+        .appliedToType(returnType)
+        .appliedTo(ref(continuation1.symbol))
+        .appliedToNone
+
+    val safeContinuationConstructor =
+      New(ref(safeContinuationClassSym))
+        .select(nme.CONSTRUCTOR)
+        .appliedToType(returnType)
+        .appliedTo(interceptedCall, undecidedState)
+
+    val safeContinuation: ValDef =
+      ValDef(
+        newSymbol(
+          parent,
+          termName("safeContinuation"),
+          Flags.Local,
+          safeContinuationConstructor.tpe),
+        safeContinuationConstructor)
+
+    val safeContinuationRef =
+      ref(safeContinuation.symbol)
+
+    val suspendContinuation: ValDef =
+      ValDef(
+        newSymbol(
+          parent,
+          termName("suspendContinuation"),
+          Flags.Local,
+          ctx.definitions.IntType),
+        Literal(Constant(0))
+      )
+
+    val suspendContinuationResume =
+      safeContinuationRef.select(termName("resume")).appliedTo(resumeArg)
+
+    val suspendContinuationGetThrow =
+      safeContinuationRef.select(termName("getOrThrow")).appliedToNone
+
+    val body = Block(
+      rowsBeforeSuspend ++
+        (continuation1 :: safeContinuation :: suspendContinuation :: suspendContinuationResume :: Nil),
+      suspendContinuationGetThrow
+    )
+
+    val suspendedState =
+      ref(continuationObjectSym).select(termName("State")).select(termName("Suspended"))
+
+    val finalMethodReturnType =
+      OrType(
+        OrType(ctx.definitions.AnyType, ctx.definitions.NullType, soft = false),
+        suspendedState.symbol.namedType,
+        soft = false)
+
+    DefDef(parent.asTerm, List(List(completion)), finalMethodReturnType, body)
+
+  def transformSuspendContinuation(tree: DefDef): DefDef =
+    tree match
+      case HasSuspendParameter(_) =>
+        tree match
+          case CallsContinuationResumeWith(resumeArg) =>
+            transformSuspendNoParametersOneContinuationResume(tree, resumeArg)
+          case _ => tree
+      case _ => tree
+}
+
+object DefDefTransforms {
+  private val suspendFullName = "continuations.Suspend"
+  private val suspendContinuationFullName = "continuations.Continuation.suspendContinuation"
+  private val resumeFullName = "continuations.Continuation.resume"
+
+  object HasSuspendParameter {
+    def unapply(tree: tpd.DefDef)(using c: Context): Option[tpd.DefDef] =
+      Option(tree).filter {
+        _.paramss.exists {
+          _.exists { v =>
+            v.symbol.is(Flags.Given) && v.tpe.classSymbol.showFullName == suspendFullName
+          }
+        }
+      }
+  }
+
+  object CallsContinuationResumeWith {
+    def unapply(tree: tpd.DefDef)(using c: Context): Option[tpd.Tree] =
+      val args =
+        tree
+          .rhs
+          .toList
+          .flatMap {
+            case Block(trees, tree) => trees :+ tree
+            case tree => List(tree)
+          }
+          .filter { _.symbol.showFullName == suspendContinuationFullName }
+          .flatMap(_.filterSubTrees(_.symbol.showFullName == resumeFullName))
+          .flatMap {
+            case Apply(_, List(arg)) => Option(arg)
+            case _ => None
+          }
+
+      Option.when(args.size == 1)(args.head)
+  }
+}

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -9,21 +9,15 @@ import dotty.tools.dotc.core.Contexts.{ctx, Context}
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.StdNames.nme
-import dotty.tools.dotc.core.Symbols.{newSymbol, ClassSymbol, Symbol, TermSymbol}
+import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.{OrType, Type}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.List
 import scala.collection.mutable.ListBuffer
 
-class DefDefTransforms(
-    continuationTraitSym: ClassSymbol,
-    safeContinuationClassSym: ClassSymbol,
-    interceptedMethodSym: TermSymbol
-)(using Context) {
+class DefDefTransforms(using Context) {
   import tpd.*
-
-  private val continuationObjectSym: Symbol = continuationTraitSym.companionModule
 
   /*
    * It works with only one top level `suspendContinuation` that just calls `resume`
@@ -32,6 +26,15 @@ class DefDefTransforms(
   private def transformSuspendNoParametersOneContinuationResume(
       tree: DefDef,
       resumeArg: Tree): DefDef =
+    val continuationTraitSym: ClassSymbol =
+      requiredClass("continuations.Continuation")
+    val continuationObjectSym: Symbol =
+      continuationTraitSym.companionModule
+    val safeContinuationClassSym: ClassSymbol =
+      requiredClass("continuations.SafeContinuation")
+    val interceptedMethodSym: TermSymbol =
+      requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
+
     val parent: Symbol = tree.symbol
     val returnType: Type =
       tree

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -143,7 +143,7 @@ object DefDefTransforms {
   private val resumeFullName = "continuations.Continuation.resume"
 
   object HasSuspendParameter {
-    def unapply(tree: tpd.DefDef)(using c: Context): Option[tpd.DefDef] =
+    def unapply(tree: tpd.DefDef)(using Context): Option[tpd.DefDef] =
       Option(tree).filter {
         _.paramss.exists {
           _.exists { v =>
@@ -154,7 +154,7 @@ object DefDefTransforms {
   }
 
   object CallsContinuationResumeWith {
-    def unapply(tree: tpd.DefDef)(using c: Context): Option[tpd.Tree] =
+    def unapply(tree: tpd.DefDef)(using Context): Option[tpd.Tree] =
       val args =
         tree
           .rhs

--- a/continuationsPlugin/src/main/scala/continuations/SafeContinuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/SafeContinuation.scala
@@ -37,7 +37,7 @@ class SafeContinuation[-T](val delegate: Continuation[T], initialResult: Any | N
     else if (result.isInstanceOf[Right[_, _]])
       result.asInstanceOf[Right[_, _]].value
     else
-      result // COROUTINE_SUSPENDED
+      result // Continuation.State.Suspended
 
   override def callerFrame: ContinuationStackFrame | Null =
     if (delegate != null && delegate.isInstanceOf[ContinuationStackFrame]) delegate.asInstanceOf

--- a/continuationsPlugin/src/main/scala/continuations/SafeContinuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/SafeContinuation.scala
@@ -34,7 +34,10 @@ class SafeContinuation[-T](val delegate: Continuation[T], initialResult: Any | N
     if (result == Continuation.State.Resumed) Continuation.State.Suspended
     else if (result.isInstanceOf[Left[_, _]])
       throw result.asInstanceOf[Left[Throwable, _]].value
-    else result
+    else if (result.isInstanceOf[Right[_, _]])
+      result.asInstanceOf[Right[_, _]].value
+    else
+      result // COROUTINE_SUSPENDED
 
   override def callerFrame: ContinuationStackFrame | Null =
     if (delegate != null && delegate.isInstanceOf[ContinuationStackFrame]) delegate.asInstanceOf

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -181,6 +181,5 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
       case (tree, _) =>
         assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedLeft)
     }
-
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -92,6 +92,17 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |  Continuation.suspendContinuation[Int] { continuation => continuation.resume(Left(new Exception("error"))) }
            |""".stripMargin
 
+      val sourceRowsBefore =
+        """|
+           |package continuations
+           |
+           |def foo()(using Suspend): Int = {
+           |  val x = 5
+           |  println("HI")
+           |  Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |}
+           |""".stripMargin
+
       // format: off
       val expected =
         """|
@@ -144,6 +155,34 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |  }
            |}
            |""".stripMargin
+
+      val expectedRowsBefore =
+        """|
+           |package continuations {
+           |  final lazy module val compileFromString$package: 
+           |    continuations.compileFromString$package
+           |   = new continuations.compileFromString$package()
+           |  @SourceFile("compileFromString.scala") final module class 
+           |    compileFromString$package
+           |  () extends Object() { this: continuations.compileFromString$package.type =>
+           |    private def writeReplace(): AnyRef = 
+           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
+           |      {
+           |        val x: Int = 5
+           |        println("HI")
+           |        val continuation1: continuations.Continuation[Int] = completion
+           |        val safeContinuation: continuations.SafeContinuation[Int] = 
+           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |            continuations.Continuation.State.Undecided
+           |          )
+           |        val suspendContinuation: Int = 0
+           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |        safeContinuation.getOrThrow()
+           |      }
+           |  }
+           |}
+           |""".stripMargin
       // format: on
 
       checkContinuations(source) {
@@ -154,6 +193,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
       checkContinuations(sourceLeft) {
         case (tree, _) =>
           assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedLeft)
+      }
+
+      checkContinuations(sourceRowsBefore) {
+        case (tree, _) =>
+          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedRowsBefore)
       }
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -276,7 +276,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  Continuation.suspendContinuation[Int] { _ => Right(1) }
+           |  Continuation.suspendContinuation[Int] { _ => () }
            |""".stripMargin
 
       // format: off
@@ -291,21 +291,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |  () extends Object() { this: continuations.compileFromString$package.type =>
            |    private def writeReplace(): AnyRef = 
            |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo()(using x$1: continuations.Suspend): Int = 
-           |      continuations.Continuation.suspendContinuation[Int](
-           |        {
-           |          {
-           |            def $anonfun(_$1: continuations.Continuation[Int]): Unit = 
-           |              {
-           |                {
-           |                  Right.apply[Nothing, Int](1)
-           |                  ()
-           |                }
-           |              }
-           |            closure($anonfun)
-           |          }
-           |        }
-           |      )(x$1)
+           |    def foo()(using x$1: continuations.Suspend): Int = ??? :Int
            |  }
            |}
            |""".stripMargin
@@ -345,28 +331,8 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
            |    def foo()(using x$1: continuations.Suspend): Int = 
            |      {
-           |        continuations.Continuation.suspendContinuation[Int](
-           |          {
-           |            {
-           |              def $anonfun(continuation: continuations.Continuation[Int]): Unit = 
-           |                {
-           |                  continuation.resume(Right.apply[Nothing, Int](1))
-           |                }
-           |              closure($anonfun)
-           |            }
-           |          }
-           |        )(x$1)
-           |        continuations.Continuation.suspendContinuation[Int](
-           |          {
-           |            {
-           |              def $anonfun(continuation: continuations.Continuation[Int]): Unit = 
-           |                {
-           |                  continuation.resume(Right.apply[Nothing, Int](1))
-           |                }
-           |              closure($anonfun)
-           |            }
-           |          }
-           |        )(x$1)
+           |        ??? :Int
+           |        ??? :Int
            |      }
            |  }
            |}

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -13,7 +13,7 @@ import munit.FunSuite
 class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
 
   compilerContextWithContinuationsPlugin.test(
-    "It should work when there are no continuations") { implicit givenContext =>
+    "It should work when there are no continuations".ignore) { implicit givenContext =>
     val source = """|class A""".stripMargin
     // format: off
     val expected = """|package <empty> {
@@ -29,7 +29,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
 
   }
   compilerContextWithContinuationsPlugin.test(
-    "It should work when there are no continuations".fail) { implicit givenContext =>
+    "It should work when there are no continuations".fail.ignore) { implicit givenContext =>
     val source = """|class A""".stripMargin
     val expected = """|package <empty> {
                       |  @SourceFile("compileFromString.scala") class B() extends Object() {}
@@ -41,7 +41,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
 
   }
 
-  compilerContext.test("it should run the compiler") { implicit givenContext =>
+  compilerContext.test("it should run the compiler".ignore) { implicit givenContext =>
     val source = """
                    |class A
                    |class B extends A
@@ -72,4 +72,115 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
     }
   }
 
+  compilerContextWithContinuationsPlugin.test(
+    "it should convert simple suspended def with no parameters") { implicit givenContext =>
+
+    // FROM
+    def foo()(using Suspend): Int =
+      Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+
+    /*
+     * Is the initial code in the task correct?
+     * seems different from the Kotlin one `kotlin.coroutines.Continuation.kt`,
+     * https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/src/kotlin/coroutines/Continuation.kt#L142,
+     * there is `suspendCoroutineUninterceptedOrReturn`.
+     * Also return type cannot be Int
+     *
+     * https://github.com/arrow-kt/arrow/tree/main/arrow-libs/fx/arrow-fx-coroutines#suspendcoroutine
+     * https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/src/kotlin/coroutines/SafeContinuationJvm.kt#L20
+     */
+    // TO
+    def fooConverted(
+        completion: Continuation[Int]): Any | Null | Continuation.State.Suspended.type = {
+      import continuations.intrinsics.intercepted
+
+      val continuation1: Continuation[Int] = completion
+      val safeContinuation: SafeContinuation[Int] =
+        SafeContinuation[Int](continuation1.intercepted(), Continuation.State.Undecided)
+      val suspendContinuation = 0
+      safeContinuation.resume(Right(Int.box(1)))
+      safeContinuation.getOrThrow()
+    }
+
+    val source =
+      """|
+         |package continuations
+         |
+         |def foo()(using Suspend): Int =
+         |  Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+         |""".stripMargin
+
+    val sourceLeft =
+      """|
+         |package continuations
+         |
+         |def foo()(using Suspend): Int =
+         |  Continuation.suspendContinuation[Int] { continuation => continuation.resume(Left(new Exception("error"))) }
+         |""".stripMargin
+
+    // format: off
+    val expected =
+      """|
+         |package continuations {
+         |  final lazy module val compileFromString$package: 
+         |    continuations.compileFromString$package
+         |   = new continuations.compileFromString$package()
+         |  @SourceFile("compileFromString.scala") final module class 
+         |    compileFromString$package
+         |  () extends Object() { this: continuations.compileFromString$package.type =>
+         |    private def writeReplace(): AnyRef = 
+         |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+         |    def foo(completion: continuations.Continuation[Int]): Any = 
+         |      {
+         |        val continuation1: continuations.Continuation[Int] = completion
+         |        val safeContinuation: continuations.SafeContinuation[Int] = 
+         |          continuations.SafeContinuation.apply[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+         |            continuations.Continuation.State.Undecided
+         |          )
+         |        val suspendContinuation: Int = 0
+         |        continuations.SafeContinuation[Int]#resume(Right.apply[Nothing, Int](1))
+         |        continuations.SafeContinuation[Int]#getOrThrow()
+         |      }
+         |  }
+         |}
+         |""".stripMargin
+
+    val expectedLeft =
+      """|
+         |package continuations {
+         |  final lazy module val compileFromString$package: 
+         |    continuations.compileFromString$package
+         |   = new continuations.compileFromString$package()
+         |  @SourceFile("compileFromString.scala") final module class 
+         |    compileFromString$package
+         |  () extends Object() { this: continuations.compileFromString$package.type =>
+         |    private def writeReplace(): AnyRef = 
+         |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+         |    def foo(completion: continuations.Continuation[Int]): Any = 
+         |      {
+         |        val continuation1: continuations.Continuation[Int] = completion
+         |        val safeContinuation: continuations.SafeContinuation[Int] = 
+         |          continuations.SafeContinuation.apply[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+         |            continuations.Continuation.State.Undecided
+         |          )
+         |        val suspendContinuation: Int = 0
+         |        continuations.SafeContinuation[Int]#resume(Left.apply[Exception, Nothing](new Exception("error")))
+         |        continuations.SafeContinuation[Int]#getOrThrow()
+         |      }
+         |  }
+         |}
+         |""".stripMargin
+    // format: on
+
+    checkContinuations(source) {
+      case (tree, _) =>
+        assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+    }
+
+    checkContinuations(sourceLeft) {
+      case (tree, _) =>
+        assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedLeft)
+    }
+
+  }
 }

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -119,6 +119,144 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
   }
 
   compilerContextWithContinuationsPlugin.test(
+    "it should convert simple suspended def with no parameters with a Right input using braces") {
+    implicit givenContext =>
+
+      val source =
+        """|
+           |package continuations
+           |
+           |def foo()(using Suspend): Int =
+           |  Continuation.suspendContinuation[Int](continuation => continuation.resume(Right(1)))
+           |""".stripMargin
+
+      // format: off
+      val expected =
+        """|
+           |package continuations {
+           |  final lazy module val compileFromString$package: 
+           |    continuations.compileFromString$package
+           |   = new continuations.compileFromString$package()
+           |  @SourceFile("compileFromString.scala") final module class 
+           |    compileFromString$package
+           |  () extends Object() { this: continuations.compileFromString$package.type =>
+           |    private def writeReplace(): AnyRef = 
+           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
+           |      {
+           |        val continuation1: continuations.Continuation[Int] = completion
+           |        val safeContinuation: continuations.SafeContinuation[Int] = 
+           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |            continuations.Continuation.State.Undecided
+           |          )
+           |        val suspendContinuation: Int = 0
+           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |        safeContinuation.getOrThrow()
+           |      }
+           |  }
+           |}
+           |""".stripMargin
+      // format: on
+
+      checkContinuations(source) {
+        case (tree, _) =>
+          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+      }
+  }
+
+  compilerContextWithContinuationsPlugin.test(
+    "it should convert simple suspended def with no parameters with a Right input but no inner var") {
+    implicit givenContext =>
+
+      val source =
+        """|
+           |package continuations
+           |
+           |def foo()(using Suspend): Int =
+           |  Continuation.suspendContinuation[Int] { _.resume(Right(1)) }
+           |""".stripMargin
+
+      // format: off
+      val expected =
+        """|
+           |package continuations {
+           |  final lazy module val compileFromString$package: 
+           |    continuations.compileFromString$package
+           |   = new continuations.compileFromString$package()
+           |  @SourceFile("compileFromString.scala") final module class 
+           |    compileFromString$package
+           |  () extends Object() { this: continuations.compileFromString$package.type =>
+           |    private def writeReplace(): AnyRef = 
+           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
+           |      {
+           |        val continuation1: continuations.Continuation[Int] = completion
+           |        val safeContinuation: continuations.SafeContinuation[Int] = 
+           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |            continuations.Continuation.State.Undecided
+           |          )
+           |        val suspendContinuation: Int = 0
+           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |        safeContinuation.getOrThrow()
+           |      }
+           |  }
+           |}
+           |""".stripMargin
+      // format: on
+
+      checkContinuations(source) {
+        case (tree, _) =>
+          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+      }
+  }
+
+  compilerContextWithContinuationsPlugin.test(
+    "it should convert simple suspended def with no parameters with a Right input but no inner var using braces") {
+    implicit givenContext =>
+
+      val source =
+        """|
+           |package continuations
+           |
+           |def foo()(using Suspend): Int =
+           |  Continuation.suspendContinuation[Int](_.resume(Right(1)))
+           |""".stripMargin
+
+      // format: off
+      val expected =
+        """|
+           |package continuations {
+           |  final lazy module val compileFromString$package: 
+           |    continuations.compileFromString$package
+           |   = new continuations.compileFromString$package()
+           |  @SourceFile("compileFromString.scala") final module class 
+           |    compileFromString$package
+           |  () extends Object() { this: continuations.compileFromString$package.type =>
+           |    private def writeReplace(): AnyRef = 
+           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
+           |      {
+           |        val continuation1: continuations.Continuation[Int] = completion
+           |        val safeContinuation: continuations.SafeContinuation[Int] = 
+           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |            continuations.Continuation.State.Undecided
+           |          )
+           |        val suspendContinuation: Int = 0
+           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |        safeContinuation.getOrThrow()
+           |      }
+           |  }
+           |}
+           |""".stripMargin
+      // format: on
+
+      checkContinuations(source) {
+        case (tree, _) =>
+          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+      }
+  }
+
+  compilerContextWithContinuationsPlugin.test(
     "it should convert simple suspended def with no parameters with a Left input") {
     implicit givenContext =>
 

--- a/continuationsPlugin/src/test/scala/continuations/DefDefTransformsSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/DefDefTransformsSuite.scala
@@ -2,61 +2,207 @@ package continuations
 
 import continuations.DefDefTransforms.{CallsContinuationResumeWith, HasSuspendParameter}
 import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.{ctx, Context}
+import dotty.tools.dotc.core.Flags.EmptyFlags
 import dotty.tools.dotc.core.Names.termName
-import dotty.tools.dotc.core.Symbols.{newAnonFun, requiredClass, requiredModule}
-import dotty.tools.dotc.core.{Constants, Flags, Names, Symbols}
+import dotty.tools.dotc.core.StdNames.nme
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.{Constants, Flags, Names}
 import munit.FunSuite
 
 class DefDefTransformsSuite extends FunSuite, CompilerFixtures {
   compilerContextWithContinuationsPlugin.test(
-    "#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
+    "HasSuspendParameter#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
     case given Context =>
-      val c = summon[Context]
-      val suspend = Symbols.requiredClass("continuations.Suspend")
+      val suspend = requiredClass("continuations.Suspend")
       val d = tpd.DefDef(
-        Symbols
-          .newSymbol(
-            c.owner,
-            Names.termName("mySuspend"),
-            Flags.EmptyFlags,
-            c.definitions.IntType)
-          .asTerm,
+        newSymbol(
+          ctx.owner,
+          Names.termName("mySuspend"),
+          EmptyFlags,
+          ctx.definitions.IntType).asTerm,
         List(
           List(),
           List(
-            Symbols.newSymbol(
-              c.owner,
+            newSymbol(
+              ctx.owner,
               Names.termName("x$1"),
               Flags.union(Flags.GivenOrImplicit, Flags.Param),
               suspend.info))),
-        c.definitions.IntType,
-        tpd.Literal(Constants.Constant(1))
+        ctx.definitions.IntType,
+        tpd.Literal(Constant(1))
       )
 
       assertEquals(HasSuspendParameter.unapply(d), Some(d))
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "#unapply(defDefTree): def mySuspend(s: Suspend): Int = 1 should be None") {
+    "HasSuspendParameter#unapply(defDefTree): def mySuspend(s: Suspend): Int = 1 should be None") {
     case given Context =>
-      val c = summon[Context]
-      val suspend = Symbols.requiredClass("continuations.Suspend")
+      val suspend = requiredClass("continuations.Suspend")
       val d = tpd.DefDef(
-        Symbols
-          .newSymbol(
-            c.owner,
-            Names.termName("mySuspend"),
-            Flags.EmptyFlags,
-            c.definitions.IntType)
-          .asTerm,
+        newSymbol(
+          ctx.owner,
+          Names.termName("mySuspend"),
+          EmptyFlags,
+          ctx.definitions.IntType).asTerm,
         List(
-          List(Symbols
-            .newSymbol(c.owner, Names.termName("s"), Flags.union(Flags.Param), suspend.info))),
-        c.definitions.IntType,
-        tpd.Literal(Constants.Constant(1))
+          List(
+            newSymbol(ctx.owner, Names.termName("s"), Flags.union(Flags.Param), suspend.info))),
+        ctx.definitions.IntType,
+        tpd.Literal(Constant(1))
       )
 
       assertEquals(HasSuspendParameter.unapply(d), None)
+  }
+
+  compilerContextWithContinuationsPlugin.test(
+    "CallsContinuationResumeWith#unapply(defDefTree): def mySuspend()(using Suspend): Int = " +
+      "Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) } should be Some(tree) " +
+      "where true == Right(1)") {
+    case given Context =>
+      import tpd.*
+
+      val suspend = requiredClass("continuations.Suspend")
+      val continuation = requiredModule("continuations.Continuation")
+      val right = requiredModule("scala.util.Right")
+
+      val intType = ctx.definitions.IntType
+
+      val usingSuspend =
+        newSymbol(
+          ctx.owner,
+          Names.termName("x$1"),
+          Flags.union(Flags.GivenOrImplicit, Flags.Param),
+          suspend.info)
+
+      val anonFunc =
+        newAnonFun(ctx.owner, continuation.companionClass.info)
+
+      val continuationVal = newSymbol(
+        ctx.owner,
+        Names.termName("continuation"),
+        EmptyFlags,
+        continuation.companionClass.typeRef.appliedTo(intType)
+      )
+
+      val rightOne =
+        ref(right)
+          .select(termName("apply"))
+          .appliedToTypes(List(ctx.definitions.ThrowableType, intType))
+          .appliedTo(Literal(Constant(1)))
+
+      val rhs =
+        Inlined(
+          Apply(
+            Apply(
+              TypeApply(
+                ref(continuation).select(termName("suspendContinuation")),
+                List(TypeTree(intType))),
+              List(
+                Block(
+                  Nil,
+                  Block(
+                    List(
+                      DefDef(
+                        anonFunc,
+                        List(List(continuationVal)),
+                        ctx.definitions.UnitType,
+                        Block(
+                          Nil,
+                          ref(continuationVal).select(termName("resume")).appliedTo(rightOne))
+                      )),
+                    Closure(Nil, ref(anonFunc), TypeTree(ctx.definitions.UnitType))
+                  )
+                ))
+            ),
+            List(ref(usingSuspend))
+          ),
+          List.empty,
+          EmptyTree
+        )
+
+      val d = DefDef(
+        newSymbol(ctx.owner, Names.termName("mySuspend"), EmptyFlags, intType).asTerm,
+        List(List(), List(usingSuspend)),
+        intType,
+        rhs
+      )
+
+      assertEquals(CallsContinuationResumeWith.unapply(d), Some(rightOne))
+  }
+
+  compilerContextWithContinuationsPlugin.test(
+    "CallsContinuationResumeWith#unapply(defDefTree): def mySuspend()(using Suspend): Int = " +
+      "Continuation.suspendContinuation[Int] { continuation => () } should be None") {
+    case given Context =>
+      import tpd.*
+
+      val suspend = requiredClass("continuations.Suspend")
+      val continuation = requiredModule("continuations.Continuation")
+      val right = requiredModule("scala.util.Right")
+
+      val intType = ctx.definitions.IntType
+
+      val usingSuspend =
+        newSymbol(
+          ctx.owner,
+          Names.termName("x$1"),
+          Flags.union(Flags.GivenOrImplicit, Flags.Param),
+          suspend.info)
+
+      val anonFunc =
+        newAnonFun(ctx.owner, continuation.companionClass.info)
+
+      val continuationVal = newSymbol(
+        ctx.owner,
+        Names.termName("continuation"),
+        EmptyFlags,
+        continuation.companionClass.typeRef.appliedTo(intType)
+      )
+
+      val rightOne =
+        ref(right)
+          .select(termName("apply"))
+          .appliedToTypes(List(ctx.definitions.ThrowableType, intType))
+          .appliedTo(Literal(Constant(1)))
+
+      val rhs =
+        Inlined(
+          Apply(
+            Apply(
+              TypeApply(
+                ref(continuation).select(termName("suspendContinuation")),
+                List(TypeTree(intType))),
+              List(
+                Block(
+                  Nil,
+                  Block(
+                    List(
+                      DefDef(
+                        anonFunc,
+                        List(List(continuationVal)),
+                        ctx.definitions.UnitType,
+                        Block(Nil, ref(ctx.definitions.UnitClass))
+                      )),
+                    Closure(Nil, ref(anonFunc), TypeTree(ctx.definitions.UnitType))
+                  )
+                ))
+            ),
+            List(ref(usingSuspend))
+          ),
+          List.empty,
+          EmptyTree
+        )
+
+      val d = DefDef(
+        newSymbol(ctx.owner, Names.termName("mySuspend"), EmptyFlags, intType).asTerm,
+        List(List(), List(usingSuspend)),
+        intType,
+        rhs
+      )
+
+      assertEquals(CallsContinuationResumeWith.unapply(d), None)
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/DefDefTransformsSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/DefDefTransformsSuite.scala
@@ -1,0 +1,62 @@
+package continuations
+
+import continuations.DefDefTransforms.{CallsContinuationResumeWith, HasSuspendParameter}
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.{ctx, Context}
+import dotty.tools.dotc.core.Names.termName
+import dotty.tools.dotc.core.Symbols.{newAnonFun, requiredClass, requiredModule}
+import dotty.tools.dotc.core.{Constants, Flags, Names, Symbols}
+import munit.FunSuite
+
+class DefDefTransformsSuite extends FunSuite, CompilerFixtures {
+  compilerContextWithContinuationsPlugin.test(
+    "#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
+    case given Context =>
+      val c = summon[Context]
+      val suspend = Symbols.requiredClass("continuations.Suspend")
+      val d = tpd.DefDef(
+        Symbols
+          .newSymbol(
+            c.owner,
+            Names.termName("mySuspend"),
+            Flags.EmptyFlags,
+            c.definitions.IntType)
+          .asTerm,
+        List(
+          List(),
+          List(
+            Symbols.newSymbol(
+              c.owner,
+              Names.termName("x$1"),
+              Flags.union(Flags.GivenOrImplicit, Flags.Param),
+              suspend.info))),
+        c.definitions.IntType,
+        tpd.Literal(Constants.Constant(1))
+      )
+
+      assertEquals(HasSuspendParameter.unapply(d), Some(d))
+  }
+
+  compilerContextWithContinuationsPlugin.test(
+    "#unapply(defDefTree): def mySuspend(s: Suspend): Int = 1 should be None") {
+    case given Context =>
+      val c = summon[Context]
+      val suspend = Symbols.requiredClass("continuations.Suspend")
+      val d = tpd.DefDef(
+        Symbols
+          .newSymbol(
+            c.owner,
+            Names.termName("mySuspend"),
+            Flags.EmptyFlags,
+            c.definitions.IntType)
+          .asTerm,
+        List(
+          List(Symbols
+            .newSymbol(c.owner, Names.termName("s"), Flags.union(Flags.Param), suspend.info))),
+        c.definitions.IntType,
+        tpd.Literal(Constants.Constant(1))
+      )
+
+      assertEquals(HasSuspendParameter.unapply(d), None)
+  }
+}

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -58,7 +58,7 @@ def program: Suspend ?=> Int =
   val z = await(bar(x, y)) // suspension point #2
   c(z)
 
-def programSuspendContinuationTask2: Int =
+def programSuspendContinuationNoParamResume: Int =
   def fooTest()(using s: Suspend): Int =
     Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
 

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -59,7 +59,6 @@ def program: Suspend ?=> Int =
   c(z)
 
 def programSuspendContinuationTask2: Int =
-  // need to cast on the correct expected type?
   def fooTest()(using s: Suspend): Int =
     Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
 

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -58,6 +58,13 @@ def program: Suspend ?=> Int =
   val z = await(bar(x, y)) // suspension point #2
   c(z)
 
+def programSuspendContinuationTask2: Int =
+  // need to cast on the correct expected type?
+  def fooTest()(using s: Suspend): Int =
+    Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+
+  fooTest()
+
 import continuations.jvm.internal.ContinuationImpl
 
 final class program$continuation$1(override val completion: Continuation[Any | Null])

--- a/continuationsPluginExample/src/main/scala/examples/Main.scala
+++ b/continuationsPluginExample/src/main/scala/examples/Main.scala
@@ -5,7 +5,7 @@ import continuations.jvm.internal.ContinuationImpl
 
 @main def main =
   //  val result: Int = program
-  val result2 = programSuspendContinuationTask2
+  val result2 = programSuspendContinuationNoParamResume
   println(result2)
 
 object main$handler extends (Continuation[Any | Null] => Any):

--- a/continuationsPluginExample/src/main/scala/examples/Main.scala
+++ b/continuationsPluginExample/src/main/scala/examples/Main.scala
@@ -4,8 +4,8 @@ import continuations.*
 import continuations.jvm.internal.ContinuationImpl
 
 @main def main =
-  val result: Int = program
-  val result2: Int = programSuspendContinuationTask2
+  //  val result: Int = program
+  val result2 = programSuspendContinuationTask2
   println(result2)
 
 object main$handler extends (Continuation[Any | Null] => Any):

--- a/continuationsPluginExample/src/main/scala/examples/Main.scala
+++ b/continuationsPluginExample/src/main/scala/examples/Main.scala
@@ -5,7 +5,8 @@ import continuations.jvm.internal.ContinuationImpl
 
 @main def main =
   val result: Int = program
-  println(result)
+  val result2: Int = programSuspendContinuationTask2
+  println(result2)
 
 object main$handler extends (Continuation[Any | Null] => Any):
   override def apply($completion: Continuation[Any | Null]): Any =


### PR DESCRIPTION
~it fails currently in runtime when creating `SafeContinuation` but opening the PR for visibility~

See commit [e6c3713](https://github.com/47deg/TBD/pull/52/commits/e6c37137a4242e0223d055db4bf919006b5ef45a) for comments on what each `val` step creates