### PR TITLE
CU-43w1hxd - 0-arity suspended after non-suspending exprs and unreachable suspended

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/CallsContinuationResumeWith.scala
+++ b/continuationsPlugin/src/main/scala/continuations/CallsContinuationResumeWith.scala
@@ -26,7 +26,14 @@ private[continuations] object CallsContinuationResumeWith:
         .filterSubTrees {
           case Inlined(fun, _, _) =>
             fun.denot.matches(requiredMethod(suspendContinuationFullName))
+          case Return(_, _) => true
           case _ => false
+        }
+        .takeWhile {
+          case Return(Inlined(fun, _, _), _) =>
+            fun.denot.matches(requiredMethod(suspendContinuationFullName))
+          case Return(_, _) => false
+          case _ => true
         }
         .flatMap {
           case Inlined(


### PR DESCRIPTION
This PR ignores unreachable suspended continuations like:
```
def foo(): Suspend ?=> Int =
  val x = 3
  println("Hi")
  return x
  Continuation.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
```