### PR TITLE
CU-371zuqx Add issue template for CompilerRewriteUnsuccessfulException

### DIFF
--- a/.github/ISSUE_TEMPLATE/compilerrewriteunsuccessfulexception-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/compilerrewriteunsuccessfulexception-bug-report.md
@@ -1,0 +1,22 @@
+---
+name: CompilerRewriteUnsuccessfulException Bug report
+about: Create a report to help us improve
+title: CompilerRewriteUnsuccessfulException Bug
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. ...
+2. ...
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/compilerrewriteunsuccessfulexception-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/compilerrewriteunsuccessfulexception-bug-report.md
@@ -2,7 +2,7 @@
 name: CompilerRewriteUnsuccessfulException Bug report
 about: Create a report to help us improve
 title: CompilerRewriteUnsuccessfulException Bug
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
an issue template to point users of the compiler plugin at when they get a `CompilerRewriteUnsuccessfulException`.
related PR https://github.com/47deg/TBD/pull/58