### PR TITLE
Nested continuations replaced in the correct place

### DIFF
--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -504,14 +504,16 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |      {
            |        val x: Int = 5
            |        println("HI")
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        val suspendContinuation: Int = 0
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
+           |        {
+           |          val continuation1: continuations.Continuation[Int] = completion
+           |          val safeContinuation: continuations.SafeContinuation[Int] = 
+           |            new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |              continuations.Continuation.State.Undecided
+           |            )
+           |          val suspendContinuation: Int = 0
+           |          safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |          safeContinuation.getOrThrow()
+           |        }
            |      }
            |  }
            |}
@@ -524,8 +526,9 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
       }
   }
 
+  // TODO: revisit this test after #43w1jzc is done
   compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters ignoring any rows after the suspend call") {
+    "it should convert simple suspended def with no parameters and rows after the suspend call") {
     case given Context =>
       val source =
         """|
@@ -555,14 +558,17 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |      {
            |        val x: Int = 5
            |        println("HI")
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        val suspendContinuation: Int = 0
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
+           |        {
+           |          val continuation1: continuations.Continuation[Int] = completion
+           |          val safeContinuation: continuations.SafeContinuation[Int] = 
+           |            new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |              continuations.Continuation.State.Undecided
+           |            )
+           |          val suspendContinuation: Int = 0
+           |          safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |          safeContinuation.getOrThrow()
+           |        }
+           |        10
            |      }
            |  }
            |}
@@ -695,6 +701,69 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |        val suspendContinuation: Int = 0
            |        safeContinuation.resume(Right.apply[Nothing, Int](x.+(1)))
            |        safeContinuation.getOrThrow()
+           |      }
+           |  }
+           |}
+           |""".stripMargin
+      // format: on
+
+      checkContinuations(source) {
+        case (tree, _) =>
+          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+      }
+  }
+
+  compilerContextWithContinuationsPlugin.test(
+    "it should convert simple nested suspended def with a single parameter keeping the rest of the rows untouched") {
+    case given Context =>
+      val source =
+        """|
+           |package continuations
+           |
+           |def foo(x: Int)(using Suspend): Int = {
+           |  val y = 5
+           |  println("HI")       
+           |  if (x < y) then {
+           |    x
+           |  } else {
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  }
+           |}
+           |""".stripMargin
+
+      // format: off
+      val expected =
+        """|
+           |package continuations {
+           |  final lazy module val compileFromString$package: 
+           |    continuations.compileFromString$package
+           |   = new continuations.compileFromString$package()
+           |  @SourceFile("compileFromString.scala") final module class 
+           |    compileFromString$package
+           |  () extends Object() { this: continuations.compileFromString$package.type =>
+           |    private def writeReplace(): AnyRef = 
+           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+           |    def foo(x: Int, completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
+           |      {
+           |        val y: Int = 5
+           |        println("HI")
+           |        if x.<(y) then 
+           |          {
+           |            x
+           |          }
+           |         else 
+           |          {
+           |            {
+           |              val continuation1: continuations.Continuation[Int] = completion
+           |              val safeContinuation: continuations.SafeContinuation[Int] = 
+           |                new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+           |                  continuations.Continuation.State.Undecided
+           |                )
+           |              val suspendContinuation: Int = 0
+           |              safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |              safeContinuation.getOrThrow()
+           |            }
+           |          }
            |      }
            |  }
            |}


### PR DESCRIPTION
Previously, with a program like this:

```scala
def foo(x: Int)(using s: Suspend): Int =
  if x < 5 then {
    47
  } else {
    s.suspendContinuation[Int] { continuation =>
      continuation.resume(Right(1))
    }
  }
```
the continuation would remain the same inside the `else` branch, and the conversion to CPS would have occurred at last, outside the `if then else`, instead of replacing the original continuation:

```scala
def foo(x: Int, completion: continuations.Continuation[Int]): Any | Null | 
    (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
  {
    if x.<(5) then
      {
        47
      }
     else
      {
        {
          val Suspend_this: (s : continuations.Suspend) = s
          (throw
            Suspend_this.
              continuations$Suspend$$inline$CompilerRewriteUnsuccessfulException
          ):Int
        }
      }
    val continuation1: continuations.Continuation[Int] = completion
    val safeContinuation: continuations.SafeContinuation[Int] =
      new continuations.SafeContinuation[Int](
        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](
          continuation1
        )()
      , continuations.Continuation.State.Undecided)
    val suspendContinuation: Int = 0
    safeContinuation.resume(Right.apply[Nothing, Int](1))
    safeContinuation.getOrThrow()
  }
```
Now, the continuation is replaced in the appropriate place.