### PR TITLE
CU-86778g79f - Compiler Plugin: Add transformation for dependent suspendContinuations

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -284,16 +284,26 @@ object DefDefTransforms extends TreesChecks:
     val newTree =
       tree match
         case HasSuspensionNotInReturnedValue(_) =>
+          val suspensionPoints =
+            SuspensionPoints
+              .unapplySeq(report.logWith("tree has no suspension points:")(tree))
+              .toList
+              .flatten
           transformUnusedSuspensionsSuspendingStateMachine(
             tree,
+            suspensionPoints,
             suspensionInReturnedValue = false)
         case CallsSuspendContinuation(_) =>
-          SuspensionPoints.unapplySeq(tree).toList.flatMap(_.points) match
+          SuspensionPoints
+            .unapplySeq(report.logWith("tree has no suspension points:")(tree))
+            .toList
+            .flatten match
             case suspensionPoint :: Nil if !suspensionPoint.isInstanceOf[tpd.ValDef] =>
               transformSuspendOneContinuationResume(tree, suspensionPoint)
-            case _ =>
+            case suspensionPoints =>
               transformUnusedSuspensionsSuspendingStateMachine(
                 tree,
+                suspensionPoints,
                 suspensionInReturnedValue = true)
         case BodyHasSuspensionPoint(_) =>
           cpy.DefDef(tree)() // any suspension that still needs a transformation
@@ -352,13 +362,11 @@ object DefDefTransforms extends TreesChecks:
 
   private def transformUnusedSuspensionsSuspendingStateMachine(
       tree: tpd.DefDef,
+      suspensionPoints: List[tpd.Tree],
       suspensionInReturnedValue: Boolean)(using ctx: Context) =
-    SuspensionPoints
-      .unapplySeq(report.logWith("tree has no suspension points:")(tree))
-      .toList
-      .flatMap(_.points) match
+    suspensionPoints match
       case Nil => tree
-      case suspensionPoints =>
+      case _ =>
         val suspensionPointsVal: List[tpd.Tree] =
           suspensionPoints.collect { case vd: tpd.ValDef => vd }
         val suspensionPointsSize = suspensionPoints.size
@@ -543,7 +551,7 @@ object DefDefTransforms extends TreesChecks:
               defn.UnitType)
           ).entered.asTerm
 
-        val (rowsBeforeSuspensionPoints, rowsAfterLastSuspend)
+        val (rowsBeforeSuspensionPoint, rowsAfterLastSuspensionPoint)
             : (Map[tpd.Tree, List[tpd.Tree]], List[tpd.Tree]) =
           rhs
             .toList
@@ -574,15 +582,15 @@ object DefDefTransforms extends TreesChecks:
             .drop(1)
 
         val treesBeforeSuspendUsedAfterwards: List[tpd.Tree] =
-          rowsBeforeSuspensionPoints
+          rowsBeforeSuspensionPoint
             .toList
             .zipWithIndex
             .flatMap {
               case ((suspend, rows), i) =>
                 val rowsAfter =
-                  rowsBeforeSuspensionPoints.drop(i + 1).values.toList.flatten ++
-                    rowsBeforeSuspensionPoints.drop(i + 1).keySet ++ // maybe + 2
-                    rowsAfterLastSuspend
+                  rowsBeforeSuspensionPoint.drop(i + 1).values.toList.flatten ++
+                    rowsBeforeSuspensionPoint.drop(i + 1).keySet ++
+                    rowsAfterLastSuspensionPoint
 
                 (rows :+ suspend).collect { case vd: tpd.ValDef => vd }.flatMap { vd =>
                   rowsAfter.flatMap(_.shallowFold(List.empty[tpd.Tree]) {
@@ -766,13 +774,13 @@ object DefDefTransforms extends TreesChecks:
             )
 
           val labels: List[Symbol] =
-            rowsBeforeSuspensionPoints.keySet.toList.indices.toList.map { i =>
+            rowsBeforeSuspensionPoint.keySet.toList.indices.toList.map { i =>
               newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType)
             }
 
-          def paramsAndRowsBeforeIncludingSuspend(index: Int) =
+          def paramsAndRowsBeforeSuspendIncludingSuspend(index: Int) =
             transformedMethodParamsAsVals ++
-              rowsBeforeSuspensionPoints
+              rowsBeforeSuspensionPoint
                 .take(index + 1)
                 .transform { (suspend, rowsBefore) => rowsBefore :+ suspend }
                 .values
@@ -780,20 +788,20 @@ object DefDefTransforms extends TreesChecks:
                 .flatten
 
           def treesToAssignToI$Ns(
-              paramsAndRowsBeforeIncludingSuspend: List[tpd.Tree]): List[tpd.Tree] =
+              paramsAndRowsBeforeSuspendIncludingSuspend: List[tpd.Tree]): List[tpd.Tree] =
             (transformedMethodParamsAsVals ++ globalVars)
               .filter { v =>
-                paramsAndRowsBeforeIncludingSuspend
+                paramsAndRowsBeforeSuspendIncludingSuspend
                   .dropRight(1)
                   .exists(_.symbol.denot.matches(v.symbol))
               }
               .sortWith { (t1, t2) =>
-                paramsAndRowsBeforeIncludingSuspend.indexOf(t1) >
-                  paramsAndRowsBeforeIncludingSuspend.indexOf(t2)
+                paramsAndRowsBeforeSuspendIncludingSuspend.indexOf(t1) >
+                  paramsAndRowsBeforeSuspendIncludingSuspend.indexOf(t2)
               }
 
           val cases =
-            rowsBeforeSuspensionPoints.zipWithIndex.toList.map {
+            rowsBeforeSuspensionPoint.zipWithIndex.toList.map {
               case ((suspension, rowsBefore), i) =>
                 val label =
                   if (i > 0)
@@ -863,14 +871,12 @@ object DefDefTransforms extends TreesChecks:
                     safeContinuationRef.select(termName("getOrThrow")).appliedToNone)
 
                 val assignGetOrThrowToGlobalVar =
-                  rowsBeforeSuspensionPoints.keySet.toList(i) match
+                  rowsBeforeSuspensionPoint.keySet.toList(i) match
                     case vd: tpd.ValDef =>
                       tpd.Assign(
-                        globalVars
-                          .find(v =>
-                            v.symbol
-                              .name == vd.symbol.name && v.symbol.coord == vd.symbol.coord)
-                          .get,
+                        globalVars.find { v =>
+                          v.symbol.name == vd.symbol.name && v.symbol.coord == vd.symbol.coord
+                        }.get,
                         ref(suspendContinuationGetThrow.symbol)
                           .select(nme.asInstanceOf_)
                           .appliedToType(vd.symbol.info)
@@ -879,14 +885,12 @@ object DefDefTransforms extends TreesChecks:
                       tpd.EmptyTree
 
                 val assignResultToGlobalVar =
-                  rowsBeforeSuspensionPoints.keySet.toList.lift(i - 1) match
+                  rowsBeforeSuspensionPoint.keySet.toList.lift(i - 1) match
                     case Some(vd: tpd.ValDef) =>
                       tpd.Assign(
-                        globalVars
-                          .find(v =>
-                            v.symbol
-                              .name == vd.symbol.name && v.symbol.coord == vd.symbol.coord)
-                          .get,
+                        globalVars.find { v =>
+                          v.symbol.name == vd.symbol.name && v.symbol.coord == vd.symbol.coord
+                        }.get,
                         ref($result.symbol)
                           .select(nme.asInstanceOf_)
                           .appliedToType(vd.symbol.info)
@@ -908,11 +912,11 @@ object DefDefTransforms extends TreesChecks:
                     ref(suspendContinuationGetThrow.symbol)
                   else unitLiteral
 
-                val paramsAndRowsBeforeIncludingSuspendCurrent =
-                  paramsAndRowsBeforeIncludingSuspend(i)
+                val paramsAndRowsBeforeSuspendIncludingSuspendCurrent =
+                  paramsAndRowsBeforeSuspendIncludingSuspend(i)
 
                 val treesToAssignToI$NsCurrent: List[tpd.Tree] =
-                  treesToAssignToI$Ns(paramsAndRowsBeforeIncludingSuspendCurrent)
+                  treesToAssignToI$Ns(paramsAndRowsBeforeSuspendIncludingSuspendCurrent)
 
                 val assignToI$Ns =
                   treesToAssignToI$NsCurrent.zipWithIndex.map { (tree, i) =>
@@ -926,7 +930,7 @@ object DefDefTransforms extends TreesChecks:
                   assignToI$Ns
                     .map { assign => tpd.Assign(assign.rhs, assign.lhs) }
                     .filter { assign =>
-                      paramsAndRowsBeforeIncludingSuspendCurrent
+                      paramsAndRowsBeforeSuspendIncludingSuspendCurrent
                         .reverse
                         .drop(1)
                         .dropWhile(r => !treeCallsSuspend(r) && !valDefTreeCallsSuspend(r))
@@ -934,7 +938,7 @@ object DefDefTransforms extends TreesChecks:
                         .exists(_.symbol.denot.matches(assign.lhs.symbol))
                     }
 
-                val rowsBeforeUpdatedForGlobalVars: List[tpd.Tree] =
+                val rowsBeforeSuspendUpdatedForGlobalVars: List[tpd.Tree] =
                   rowsBefore.map { tree =>
                     tree match
                       case vd: tpd.ValDef =>
@@ -950,7 +954,7 @@ object DefDefTransforms extends TreesChecks:
                   tpd.Block(
                     assignFromI$Ns ++
                       List(throwOnFailure, assignResultToGlobalVar, label) ++
-                      rowsBeforeUpdatedForGlobalVars ++
+                      rowsBeforeSuspendUpdatedForGlobalVars ++
                       assignToI$Ns ++
                       List(
                         tpd.Assign(
@@ -973,8 +977,9 @@ object DefDefTransforms extends TreesChecks:
             tpd.Literal(Constant(suspensionPointsSize)),
             tpd.EmptyTree,
             tpd.Block(
-              treesToAssignToI$Ns(paramsAndRowsBeforeIncludingSuspend(
-                suspensionPoints.size - 1)).zipWithIndex.map { (tree, i) =>
+              treesToAssignToI$Ns {
+                paramsAndRowsBeforeSuspendIncludingSuspend(suspensionPoints.size - 1)
+              }.zipWithIndex.map { (tree, i) =>
                 tpd.Assign(
                   ref(tree.symbol),
                   continuationAsStateMachineClass.select(continuationStateMachineI$Ns(i).symbol)
@@ -984,10 +989,9 @@ object DefDefTransforms extends TreesChecks:
               suspensionPoints.lastOption match
                 case Some(vd: tpd.ValDef) =>
                   tpd.Assign(
-                    globalVars
-                      .find(v =>
-                        v.symbol.name == vd.symbol.name && v.symbol.coord == vd.symbol.coord)
-                      .get,
+                    globalVars.find { v =>
+                      v.symbol.name == vd.symbol.name && v.symbol.coord == vd.symbol.coord
+                    }.get,
                     ref($result.symbol).select(nme.asInstanceOf_).appliedToType(vd.symbol.info)
                   )
                 case Some(_) if suspensionInReturnedValue => ref($result.symbol)
@@ -1051,24 +1055,18 @@ object DefDefTransforms extends TreesChecks:
          * `suspendContinuation` as they are embedded in the state machine.
          */
         var c = 0
-        var rowsToRemove = rowsBeforeSuspensionPoints.values.toList.flatten.map(_.symbol.coord)
+        var rowsToRemove = rowsBeforeSuspensionPoint.values.toList.flatten.map(_.symbol.coord)
         val substituteContinuation = new TreeTypeMap(
           treeMap = {
-            case vd: tpd.ValDef
-                if vd.rhs.isInstanceOf[tpd.Inlined] &&
-                  treeCallsSuspend(vd.rhs) && c < suspensionPointsSize - 1 =>
+            case tree if valDefTreeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
               c += 1
               tpd.EmptyTree
-            case vd: tpd.ValDef
-                if vd.rhs.isInstanceOf[tpd.Inlined] &&
-                  treeCallsSuspend(vd.rhs) && c == suspensionPointsSize - 1 =>
+            case tree if valDefTreeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
               transformSuspendTree(transformedMethod.symbol)
-            case tree @ Trees.Inlined(_, _, _)
-                if treeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
+            case tree if treeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
               c += 1
               tpd.EmptyTree
-            case tree @ Trees.Inlined(_, _, _)
-                if treeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
+            case tree if treeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
               transformSuspendTree(transformedMethod.symbol)
             case tree if c < suspensionPointsSize && rowsToRemove.contains(tree.symbol.coord) =>
               rowsToRemove = rowsToRemove.zipWithIndex.collect {
@@ -1091,12 +1089,11 @@ object DefDefTransforms extends TreesChecks:
                   tt.symbol.owner.denot.matches(tree.symbol) &&
                   transformedMethodParamsWithoutCompletion.exists(
                     _.symbol.denot.matches(tt.symbol)) &&
-                  transformedMethodParamsAsVals.exists { t =>
-                    t.symbol.name.show.dropRight(3) == tt.symbol.name.show
-                  } =>
+                  transformedMethodParamsAsVals.exists(
+                    _.symbol.name.show.dropRight(3) == tt.symbol.name.show) =>
               ref(
                 transformedMethodParamsAsVals
-                  .find { t => t.symbol.name.show.dropRight(3) == tt.symbol.name.show }
+                  .find(_.symbol.name.show.dropRight(3) == tt.symbol.name.show)
                   .get
                   .symbol)
             case tree =>

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -288,11 +288,8 @@ object DefDefTransforms extends TreesChecks:
             tree,
             suspensionInReturnedValue = false)
         case CallsSuspendContinuation(_) =>
-          SuspensionPoints.unapplySeq(tree).toList.flatMap(_.points).filter {
-            case _: tpd.ValDef => false
-            case _ => true
-          } match
-            case suspensionPoint :: Nil =>
+          SuspensionPoints.unapplySeq(tree).toList.flatMap(_.points) match
+            case suspensionPoint :: Nil if !suspensionPoint.isInstanceOf[tpd.ValDef] =>
               transformSuspendOneContinuationResume(tree, suspensionPoint)
             case _ =>
               transformUnusedSuspensionsSuspendingStateMachine(

--- a/continuationsPlugin/src/main/scala/continuations/SuspensionPoints.scala
+++ b/continuationsPlugin/src/main/scala/continuations/SuspensionPoints.scala
@@ -3,8 +3,6 @@ package continuations
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.Context
 
-case class SuspensionPoints(points: List[Tree])
-
 /**
  * Extracts the trees that suspend from a tree, either assigned to a val or not.
  */
@@ -15,12 +13,12 @@ object SuspensionPoints extends TreesChecks:
    * @return
    *   A Some containing a list of [[dotty.tools.dotc.ast.tpd.Tree]]s that suspend from the body
    */
-  def unapplySeq(tree: Tree)(using Context): Option[SuspensionPoints] =
+  def unapplySeq(tree: Tree)(using Context): Option[List[Tree]] =
     val resultValNonVal = tree
       .shallowFold(List.empty[Tree]) {
         case (suspends, tree) =>
           tree match
-            case st @ ValDef(_, _, _) if subtreeCallsSuspend(st.forceIfLazy) =>
+            case vd: ValDef if subtreeCallsSuspend(vd.forceIfLazy) =>
               tree :: suspends
             case _ if treeCallsSuspend(tree) =>
               tree :: suspends
@@ -30,6 +28,6 @@ object SuspensionPoints extends TreesChecks:
       .reverse
 
     if (resultValNonVal.nonEmpty)
-      Some(SuspensionPoints(resultValNonVal))
+      Some(resultValNonVal)
     else
       Option.empty

--- a/continuationsPlugin/src/main/scala/continuations/TreesChecks.scala
+++ b/continuationsPlugin/src/main/scala/continuations/TreesChecks.scala
@@ -46,4 +46,9 @@ trait TreesChecks extends Trees {
    */
   private[continuations] def treeCallsResume[A](tree: TTree[A])(using Context): Boolean =
     tree.denot.matches(continuationResumeMethod.symbol)
+
+  private[continuations] def valDefTreeCallsSuspend(tree: Tree)(using Context): Boolean =
+    tree match
+      case vd @ ValDef(_, _, _) => treeCallsSuspend(vd.rhs)
+      case _ => false
 }

--- a/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
@@ -439,7 +439,7 @@ trait CompilerFixtures { self: FunSuite =>
   val oneTree: FunFixture[Context ?=> Literal] =
     FunFixture(setup = _ => one, teardown = _ => ())
 
-  val suspendingSingleArityWithDependentNonSuspendingCalculation =
+  val suspendingSingleArityWithDependentNonSuspendingAndNonDependentCalculation =
     FunFixture[Context ?=> DefDef](
       setup = _ => {
         val c = summon[Context]
@@ -492,7 +492,8 @@ trait CompilerFixtures { self: FunSuite =>
                         )
                     )
                   )
-              )
+              ),
+              inlinedCallToContinuationsSuspendOfInt
             ),
             ref(x).select(defn.Int_+).appliedTo(ref(y))
           )
@@ -707,10 +708,10 @@ trait CompilerFixtures { self: FunSuite =>
   val continuationsContextAndNotSuspendContextualMethodDefDef =
     FunFixture.map2(compilerContextWithContinuationsPlugin, notSuspendContextualMethodDefDef)
 
-  val continutationsContextAndSuspendingSingleArityWithDependentNonSuspendingCalculation =
+  val continutationsContextAndSuspendingSingleArityWithDependentNonSuspendingAndNonDependentCalculation =
     FunFixture.map2(
       compilerContextWithContinuationsPlugin,
-      suspendingSingleArityWithDependentNonSuspendingCalculation)
+      suspendingSingleArityWithDependentNonSuspendingAndNonDependentCalculation)
 
   val continutationsContextAndInlinedSuspendingSingleArityWithDependentNonSuspendingCalculation =
     FunFixture.map2(

--- a/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
@@ -125,6 +125,9 @@ import dotty.tools.dotc.core.StdNames.nme
 
 trait CompilerFixtures { self: FunSuite =>
 
+  def removeLineTrailingSpaces(s: String): String =
+    s.lines.map(_.stripTrailing).reduce(_ ++ "\n" ++ _).get
+
   private def usingSuspend(owner: Symbol)(using c: Context): Symbol =
     Symbols.newSymbol(
       owner,

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginFixtures.scala
@@ -1,0 +1,1108 @@
+package continuations
+
+trait ContinuationsPluginFixtures {
+  // format: off
+  val expectedStateMachineOneParamOneDependantContinuation =
+      """|
+         |package continuations {
+         |  final lazy module val compileFromString$package:
+         |    continuations.compileFromString$package
+         |   = new continuations.compileFromString$package()
+         |  @SourceFile("compileFromString.scala") final module class
+         |    compileFromString$package
+         |  () extends Object() { this: continuations.compileFromString$package.type =>
+         |    private def writeReplace(): AnyRef =
+         |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+         |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
+         |      continuations.jvm.internal.ContinuationImpl
+         |    ($completion, $completion.context) {
+         |      var I$0: Any = _
+         |      var I$1: Any = _
+         |      def I$0_=(x$0: Any): Unit = ()
+         |      def I$1_=(x$0: Any): Unit = ()
+         |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+         |      var $label: Int = _
+         |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+         |      def $label_=(x$0: Int): Unit = ()
+         |      protected override def invokeSuspend(
+         |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+         |      ): Any | Null =
+         |        {
+         |          this.$result = result
+         |          this.$label = this.$label.|(scala.Int.MinValue)
+         |          continuations.compileFromString$package.foo(null, this.asInstanceOf[continuations.Continuation[Int]])
+         |        }
+         |    }
+         |    def foo(x: Int, completion: continuations.Continuation[Int]):
+         |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+         |     =
+         |      {
+         |        var x##1: Int = x
+         |        var y: Int = null
+         |        {
+         |          var $continuation: continuations.Continuation[Any] | Null = null
+         |          completion match
+         |            {
+         |              case x$0 @ <empty> if
+         |                x$0.isInstanceOf[
+         |                  continuations.compileFromString$package.
+         |                    compileFromString$package$foo$1
+         |                ].&&(
+         |                  x$0.asInstanceOf[
+         |                    continuations.compileFromString$package.
+         |                      compileFromString$package$foo$1
+         |                  ].$label.&(scala.Int.MinValue).!=(0)
+         |                )
+         |               =>
+         |                $continuation =
+         |                  x$0.asInstanceOf[
+         |                    continuations.compileFromString$package.
+         |                      compileFromString$package$foo$1
+         |                  ]
+         |                $continuation.asInstanceOf[
+         |                  continuations.compileFromString$package.
+         |                    compileFromString$package$foo$1
+         |                ].$label =
+         |                  $continuation.asInstanceOf[
+         |                    continuations.compileFromString$package.
+         |                      compileFromString$package$foo$1
+         |                  ].$label.-(scala.Int.MinValue)
+         |              case _ =>
+         |                $continuation =
+         |                  new
+         |                    continuations.compileFromString$package.
+         |                      compileFromString$package$foo$1
+         |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+         |            }
+         |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+         |            $continuation.asInstanceOf[
+         |              continuations.compileFromString$package.
+         |                compileFromString$package$foo$1
+         |            ].$result
+         |          $continuation.asInstanceOf[
+         |            continuations.compileFromString$package.
+         |              compileFromString$package$foo$1
+         |          ].$label match
+         |            {
+         |              case 0 =>
+         |                if $result.!=(null) then
+         |                  $result.fold[Unit](
+         |                    {
+         |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+         |                      closure($anonfun)
+         |                    }
+         |                  ,
+         |                    {
+         |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+         |                      closure($anonfun)
+         |                    }
+         |                  )
+         |                 else ()
+         |                $continuation.asInstanceOf[
+         |                  continuations.compileFromString$package.
+         |                    compileFromString$package$foo$1
+         |                ].I$0 = x##1
+         |                $continuation.asInstanceOf[
+         |                  continuations.compileFromString$package.
+         |                    compileFromString$package$foo$1
+         |                ].$label = 1
+         |                val safeContinuation: continuations.SafeContinuation[Int] =
+         |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+         |                    continuations.Continuation.State.Undecided
+         |                  )
+         |                safeContinuation.resume(Right.apply[Nothing, Int](1))
+         |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+         |                  safeContinuation.getOrThrow()
+         |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+         |                y = orThrow.asInstanceOf[Int]
+         |                ()
+         |              case 1 =>
+         |                x##1 =
+         |                  $continuation.asInstanceOf[
+         |                    continuations.compileFromString$package.
+         |                      compileFromString$package$foo$1
+         |                  ].I$0
+         |                if $result.!=(null) then
+         |                  $result.fold[Unit](
+         |                    {
+         |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+         |                      closure($anonfun)
+         |                    }
+         |                  ,
+         |                    {
+         |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+         |                      closure($anonfun)
+         |                    }
+         |                  )
+         |                 else ()
+         |                y = $result.asInstanceOf[Int]
+         |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+         |            }
+         |        }
+         |        x##1.+(y)
+         |      }
+         |  }
+         |}
+         """.stripMargin
+  // format: on
+
+  val expectedStateMachineOneParamOneNoDependantContinuation =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.foo(null, this.asInstanceOf[continuations.Continuation[Int]])
+      |        }
+      |    }
+      |    def foo(qq: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var qq##1: Int = qq
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$foo$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$foo$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Unit] =
+      |                  new continuations.SafeContinuation[Unit](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Unit]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Unit](
+      |                    {
+      |                      println(qq##1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                ()
+      |              case 1 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].I$0
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                ()
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        10
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+
+  val expectedStateMachineNoParamOneNoDependantContinuationCodeBeforeUsedAfter =
+      """
+        |package continuations {
+        |  final lazy module val compileFromString$package:
+        |    continuations.compileFromString$package
+        |   = new continuations.compileFromString$package()
+        |  @SourceFile("compileFromString.scala") final module class
+        |    compileFromString$package
+        |  () extends Object() { this: continuations.compileFromString$package.type =>
+        |    private def writeReplace(): AnyRef =
+        |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+        |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
+        |      continuations.jvm.internal.ContinuationImpl
+        |    ($completion, $completion.context) {
+        |      var I$0: Any = _
+        |      def I$0_=(x$0: Any): Unit = ()
+        |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+        |      var $label: Int = _
+        |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+        |      def $label_=(x$0: Int): Unit = ()
+        |      protected override def invokeSuspend(
+        |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+        |      ): Any | Null =
+        |        {
+        |          this.$result = result
+        |          this.$label = this.$label.|(scala.Int.MinValue)
+        |          continuations.compileFromString$package.foo(this.asInstanceOf[continuations.Continuation[Int]])
+        |        }
+        |    }
+        |    def foo(completion: continuations.Continuation[Int]):
+        |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+        |     =
+        |      {
+        |        var xx: Int = null
+        |        {
+        |          var $continuation: continuations.Continuation[Any] | Null = null
+        |          completion match
+        |            {
+        |              case x$0 @ <empty> if
+        |                x$0.isInstanceOf[
+        |                  continuations.compileFromString$package.
+        |                    compileFromString$package$foo$1
+        |                ].&&(
+        |                  x$0.asInstanceOf[
+        |                    continuations.compileFromString$package.
+        |                      compileFromString$package$foo$1
+        |                  ].$label.&(scala.Int.MinValue).!=(0)
+        |                )
+        |               =>
+        |                $continuation =
+        |                  x$0.asInstanceOf[
+        |                    continuations.compileFromString$package.
+        |                      compileFromString$package$foo$1
+        |                  ]
+        |                $continuation.asInstanceOf[
+        |                  continuations.compileFromString$package.
+        |                    compileFromString$package$foo$1
+        |                ].$label =
+        |                  $continuation.asInstanceOf[
+        |                    continuations.compileFromString$package.
+        |                      compileFromString$package$foo$1
+        |                  ].$label.-(scala.Int.MinValue)
+        |              case _ =>
+        |                $continuation =
+        |                  new
+        |                    continuations.compileFromString$package.
+        |                      compileFromString$package$foo$1
+        |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+        |            }
+        |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+        |            $continuation.asInstanceOf[
+        |              continuations.compileFromString$package.
+        |                compileFromString$package$foo$1
+        |            ].$result
+        |          $continuation.asInstanceOf[
+        |            continuations.compileFromString$package.
+        |              compileFromString$package$foo$1
+        |          ].$label match
+        |            {
+        |              case 0 =>
+        |                if $result.!=(null) then
+        |                  $result.fold[Unit](
+        |                    {
+        |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+        |                      closure($anonfun)
+        |                    }
+        |                  ,
+        |                    {
+        |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+        |                      closure($anonfun)
+        |                    }
+        |                  )
+        |                 else ()
+        |                xx = 111
+        |                println(xx)
+        |                $continuation.asInstanceOf[
+        |                  continuations.compileFromString$package.
+        |                    compileFromString$package$foo$1
+        |                ].I$0 = xx
+        |                $continuation.asInstanceOf[
+        |                  continuations.compileFromString$package.
+        |                    compileFromString$package$foo$1
+        |                ].$label = 1
+        |                val safeContinuation: continuations.SafeContinuation[Int] =
+        |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+        |                    continuations.Continuation.State.Undecided
+        |                  )
+        |                safeContinuation.resume(Right.apply[Nothing, Int](10))
+        |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+        |                  safeContinuation.getOrThrow()
+        |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+        |                ()
+        |              case 1 =>
+        |                xx =
+        |                  $continuation.asInstanceOf[
+        |                    continuations.compileFromString$package.
+        |                      compileFromString$package$foo$1
+        |                  ].I$0
+        |                if $result.!=(null) then
+        |                  $result.fold[Unit](
+        |                    {
+        |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+        |                      closure($anonfun)
+        |                    }
+        |                  ,
+        |                    {
+        |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+        |                      closure($anonfun)
+        |                    }
+        |                  )
+        |                 else ()
+        |                ()
+        |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+        |            }
+        |        }
+        |        xx
+        |      }
+        |  }
+        |}
+        |""".stripMargin
+      
+  val expectedStateMachineManyDependantContinuations =
+    """
+      package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      var I$1: Any = _
+      |      var I$2: Any = _
+      |      var I$3: Any = _
+      |      var I$4: Any = _
+      |      var I$5: Any = _
+      |      var I$6: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      def I$1_=(x$0: Any): Unit = ()
+      |      def I$2_=(x$0: Any): Unit = ()
+      |      def I$3_=(x$0: Any): Unit = ()
+      |      def I$4_=(x$0: Any): Unit = ()
+      |      def I$5_=(x$0: Any): Unit = ()
+      |      def I$6_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(null,
+      |            this.asInstanceOf[continuations.Continuation[Int]]
+      |          )
+      |        }
+      |    }
+      |    def fooTest(qq: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var qq##1: Int = qq
+      |        var pp: Int = null
+      |        var xx: Int = null
+      |        var ww: Int = null
+      |        var yy: String = null
+      |        var tt: Int = null
+      |        var zz: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                pp = 11
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = pp
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      qq##1.-(1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                xx = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                pp =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                xx = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                ww = 13
+      |                val rr: String = "AAA"
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = pp
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = xx
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$3 = ww
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[String] =
+      |                  new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, String](
+      |                    {
+      |                      rr
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                yy = orThrow.asInstanceOf[String]
+      |                return[label2] ()
+      |                ()
+      |              case 2 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                pp =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                xx =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                ww =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$3
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                yy = $result.asInstanceOf[String]
+      |                label2[Unit]: <empty>
+      |                tt = 100
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = pp
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = xx
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$3 = ww
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$4 = yy
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$5 = tt
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 3
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      ww.-(1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                zz = orThrow.asInstanceOf[Int]
+      |                ()
+      |              case 3 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                pp =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                xx =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                ww =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$3
+      |                yy =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$4
+      |                tt =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$5
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                zz = $result.asInstanceOf[Int]
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        println(xx)
+      |        xx.+(qq##1).+(augmentString(yy).size).+(zz).+(pp).+(tt)
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+
+  val expectedStateMachineManyDependantAndNoDependantContinuations =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      var I$1: Any = _
+      |      var I$2: Any = _
+      |      var I$3: Any = _
+      |      var I$4: Any = _
+      |      var I$5: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      def I$1_=(x$0: Any): Unit = ()
+      |      def I$2_=(x$0: Any): Unit = ()
+      |      def I$3_=(x$0: Any): Unit = ()
+      |      def I$4_=(x$0: Any): Unit = ()
+      |      def I$5_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(null,
+      |            this.asInstanceOf[continuations.Continuation[Int]]
+      |          )
+      |        }
+      |    }
+      |    def fooTest(qq: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var qq##1: Int = qq
+      |        var pp: Int = null
+      |        var xx: Int = null
+      |        var ww: Int = null
+      |        var tt: Int = null
+      |        var zz: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                pp = 11
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = pp
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      qq##1.-(1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                xx = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                pp =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                xx = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                ww = 13
+      |                val rr: String = "AAA"
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = pp
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = xx
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$3 = ww
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[String] =
+      |                  new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, String](
+      |                    {
+      |                      rr
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                return[label2] ()
+      |                ()
+      |              case 2 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                pp =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                xx =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                ww =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$3
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                label2[Unit]: <empty>
+      |                tt = 100
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = qq##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = pp
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = xx
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$3 = ww
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$4 = tt
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 3
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      ww.-(1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                zz = orThrow.asInstanceOf[Int]
+      |                ()
+      |              case 3 =>
+      |                qq##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                pp =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                xx =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                ww =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$3
+      |                tt =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$4
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                zz = $result.asInstanceOf[Int]
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        println(xx)
+      |        xx.+(qq##1).+(zz).+(pp).+(tt)
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+}

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -214,36 +214,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedOneSuspendContinuation)
       }
   }
 
@@ -258,36 +233,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(Right(1)))
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedOneSuspendContinuation)
       }
   }
 
@@ -302,36 +252,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  summon[Suspend].suspendContinuation[Int] { _.resume(Right(1)) }
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedOneSuspendContinuation)
       }
   }
 
@@ -346,36 +271,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  summon[Suspend].suspendContinuation[Int](_.resume(Right(1)))
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedOneSuspendContinuation)
       }
   }
 
@@ -491,36 +391,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  s.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedOneSuspendContinuation)
       }
   }
 
@@ -535,36 +410,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedOneSuspendContinuation)
       }
   }
 
@@ -739,114 +589,18 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    ()
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |            10
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineForSuspendContinuationReturningANonSuspendingVal)
       }
 
       checkContinuations(sourceContextFunction) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineForSuspendContinuationReturningANonSuspendingVal)
       }
   }
 
@@ -867,114 +621,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var I$0: Any = _
-           |          def I$0_=(x$0: Any): Unit = ()
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(null, this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(x: Int, completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            var x##1: Int = x
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $continuation.asInstanceOf[program$foo$1].I$0 = x##1
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](x##1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    ()
-           |                  case 1 => 
-           |                    x##1 = $continuation.asInstanceOf[program$foo$1].I$0
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    ()
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |            10
-           |          }
-           |        foo(11, continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineWithSingleSuspendedContinuationReturningANonSuspendedVal)
       }
   }
 
@@ -1060,161 +711,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label1] ()
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label1[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-           |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-           |                      new continuations.SafeContinuation[Boolean](
-           |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-           |                      , continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label2] ()
-           |                    ()
-           |                  case 2 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label2[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-           |                    val safeContinuation: continuations.SafeContinuation[String] = 
-           |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-           |                        , 
-           |                      continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    ()
-           |                  case 3 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    ()
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |            10
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal)
       }
   }
 
@@ -1249,166 +750,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    println("Hello")
-           |                    println("World")
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label1] ()
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label1[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-           |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-           |                      new continuations.SafeContinuation[Boolean](
-           |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-           |                      , continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-           |                    safeContinuation.resume(Right.apply[Nothing, Boolean](true))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label2] ()
-           |                    ()
-           |                  case 2 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label2[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-           |                    val safeContinuation: continuations.SafeContinuation[String] = 
-           |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-           |                        , 
-           |                      continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-           |                    val x: Int = 1
-           |                    ()
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    ()
-           |                  case 3 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    ()
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |            10
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineWithMultipleResumeReturningANonSuspendedValue)
       }
   }
 
@@ -1454,145 +800,18 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    println("Start")
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label1] ()
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label1[Unit]: <empty>
-           |                    val x: String = "World"
-           |                    println("Hello")
-           |                    println(x)
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](2))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    ()
-           |                  case 2 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    ()
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |            println("End")
-           |            10
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineReturningANonSuspendedValue)
       }
 
       checkContinuations(sourceContextFunction) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineReturningANonSuspendedValue)
       }
   }
 
@@ -1615,160 +834,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-           |                      new continuations.SafeContinuation[Boolean](
-           |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-           |                      , continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label1] ()
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label1[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-           |                    val safeContinuation: continuations.SafeContinuation[String] = 
-           |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-           |                        , 
-           |                      continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label2] ()
-           |                    ()
-           |                  case 2 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label2[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    orThrow
-           |                  case 3 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $result
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineNoDependantSuspensions)
       }
   }
 
@@ -1797,162 +867,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-           |                      new continuations.SafeContinuation[Boolean](
-           |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-           |                      , continuations.Continuation.State.Undecided)
-           |                    println("Hi")
-           |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label1] ()
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label1[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-           |                    val safeContinuation: continuations.SafeContinuation[String] = 
-           |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-           |                        , 
-           |                      continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-           |                    println("World")
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label2] ()
-           |                    ()
-           |                  case 2 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label2[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    orThrow
-           |                  case 3 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $result
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineNoDependantSuspensionsWithCodeInside)
       }
   }
 
@@ -1978,163 +897,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |}
            |""".stripMargin
 
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
-           |      {
-           |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
-           |          $completion.context
-           |        ) {
-           |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-           |          var $label: Int = _
-           |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
-           |             = 
-           |          ()
-           |          def $label_=(x$0: Int): Unit = ()
-           |          protected override def invokeSuspend(
-           |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-           |          ): Any | Null = 
-           |            {
-           |              this.$result = result
-           |              this.$label = this.$label.|(scala.Int.MinValue)
-           |              foo(this.asInstanceOf[continuations.Continuation[Int]])
-           |            }
-           |        }
-           |        def foo(completion: continuations.Continuation[Int]): 
-           |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-           |         = 
-           |          {
-           |            {
-           |              var $continuation: continuations.Continuation[Any] | Null = null
-           |              completion match 
-           |                {
-           |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-           |                    $continuation = x$0.asInstanceOf[program$foo$1]
-           |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-           |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-           |                }
-           |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-           |                $continuation.asInstanceOf[program$foo$1].$result
-           |              $continuation.asInstanceOf[program$foo$1].$label match 
-           |                {
-           |                  case 0 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    println("Start")
-           |                    val x: Int = 1
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-           |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-           |                      new continuations.SafeContinuation[Boolean](
-           |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-           |                      , continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label1] ()
-           |                    ()
-           |                  case 1 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label1[Unit]: <empty>
-           |                    println("Hello")
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-           |                    val safeContinuation: continuations.SafeContinuation[String] = 
-           |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-           |                        , 
-           |                      continuations.Continuation.State.Undecided)
-           |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    return[label2] ()
-           |                    ()
-           |                  case 2 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    label2[Unit]: <empty>
-           |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-           |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-           |                        continuations.Continuation.State.Undecided
-           |                      )
-           |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-           |                      safeContinuation.getOrThrow()
-           |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-           |                    orThrow
-           |                  case 3 => 
-           |                    if $result.!=(null) then 
-           |                      $result.fold[Unit](
-           |                        {
-           |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-           |                          closure($anonfun)
-           |                        }
-           |                      , 
-           |                        {
-           |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-           |                          closure($anonfun)
-           |                        }
-           |                      )
-           |                     else ()
-           |                    $result
-           |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-           |                }
-           |            }
-           |          }
-           |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
       checkContinuations(source) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+          assertNoDiff(
+            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+            expectedStateMachineNoDependantSuspensionsWithCodeBetween)
       }
   }
 

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -2183,7 +2183,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |  () extends Object() { this: continuations.compileFromString$package.type =>
            |    private def writeReplace(): AnyRef = 
            |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
+           |    def program: Int =
            |      {
            |        def foo(x: A, y: B, z: String, ec: concurrent.ExecutionContext, completion: continuations.Continuation[A | Any]): Any = x
            |        foo(1, 2, "A", concurrent.ExecutionContext.Implicits.global, continuations.jvm.internal.ContinuationStub.contImpl)
@@ -2205,7 +2205,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
            |  () extends Object() { this: continuations.compileFromString$package.type =>
            |    private def writeReplace(): AnyRef = 
            |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int = 
+           |    def program: Int =
            |      {
            |        def foo(x: A, y: B, z: String, ec: concurrent.ExecutionContext, completion: continuations.Continuation[A]): 
            |          Any | Null | continuations.Continuation.State.Suspended.type
@@ -2228,12 +2228,16 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
 
       checkContinuations(sourceNoSuspend) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedNoSuspend)
+          assertNoDiff(
+            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+            removeLineTrailingSpaces(expectedNoSuspend))
       }
 
       checkContinuations(sourceSuspend) {
         case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedSuspend)
+          assertNoDiff(
+            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+            removeLineTrailingSpaces(expectedSuspend))
       }
   }
 

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -2428,4 +2428,482 @@ trait StateMachineFixtures {
       |  }
       |}
       |""".stripMargin
+
+  val expectedStateMachineForOneChainedContinuation =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(this.asInstanceOf[continuations.Continuation[Int]])
+      |        }
+      |    }
+      |    def fooTest(completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var x: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      1
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                x = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                x = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      x.+(1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                orThrow
+      |              case 2 =>
+      |                x =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                $result
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+
+  val expectedStateMachineMultipleChainedSuspendContinuationsReturningANonSuspendedVal =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      var I$1: Any = _
+      |      var I$2: Any = _
+      |      var I$3: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      def I$1_=(x$0: Any): Unit = ()
+      |      def I$2_=(x$0: Any): Unit = ()
+      |      def I$3_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(null,
+      |            this.asInstanceOf[continuations.Continuation[Int]]
+      |          )
+      |        }
+      |    }
+      |    def fooTest(q: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var q##1: Int = q
+      |        var x: Int = null
+      |        var j: Int = null
+      |        var w: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                println("Hello")
+      |                val z: Int = 100
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = q##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      1.+(z)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                x = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                q##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                x = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                j = 9
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = q##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = x
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = j
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      x.+(1).+(q##1)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                w = orThrow.asInstanceOf[Int]
+      |                return[label2] ()
+      |                ()
+      |              case 2 =>
+      |                q##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                x =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                j =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                w = $result.asInstanceOf[Int]
+      |                label2[Unit]: <empty>
+      |                println("World")
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = q##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = x
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = j
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$3 = w
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 3
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      x.+(w).+(1).+(j)
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                ()
+      |              case 3 =>
+      |                q##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                x =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                j =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                w =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$3
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                ()
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        10
+      |      }
+      |  }
+      |}
+      |""".stripMargin
 }

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -1,150 +1,1261 @@
 package continuations
 
 trait StateMachineFixtures {
-  // format: off
+
+  val expectedOneSuspendContinuation =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
+       |      {
+       |        val continuation1: continuations.Continuation[Int] = completion
+       |        val safeContinuation: continuations.SafeContinuation[Int] = 
+       |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
+       |            continuations.Continuation.State.Undecided
+       |          )
+       |        safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |        safeContinuation.getOrThrow()
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineForSuspendContinuationReturningANonSuspendingVal =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    ()
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |            10
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineWithSingleSuspendedContinuationReturningANonSuspendedVal =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var I$0: Any = _
+       |          def I$0_=(x$0: Any): Unit = ()
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(null, this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(x: Int, completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            var x##1: Int = x
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $continuation.asInstanceOf[program$foo$1].I$0 = x##1
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](x##1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    ()
+       |                  case 1 => 
+       |                    x##1 = $continuation.asInstanceOf[program$foo$1].I$0
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    ()
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |            10
+       |          }
+       |        foo(11, continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label1] ()
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label1[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                      new continuations.SafeContinuation[Boolean](
+       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
+       |                      , continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label2] ()
+       |                    ()
+       |                  case 2 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label2[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    val safeContinuation: continuations.SafeContinuation[String] = 
+       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
+       |                        , 
+       |                      continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    ()
+       |                  case 3 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    ()
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |            10
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineWithMultipleResumeReturningANonSuspendedValue =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    println("Hello")
+       |                    println("World")
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label1] ()
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label1[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                      new continuations.SafeContinuation[Boolean](
+       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
+       |                      , continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](true))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label2] ()
+       |                    ()
+       |                  case 2 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label2[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    val safeContinuation: continuations.SafeContinuation[String] = 
+       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
+       |                        , 
+       |                      continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                    val x: Int = 1
+       |                    ()
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    ()
+       |                  case 3 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    ()
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |            10
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineReturningANonSuspendedValue =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    println("Start")
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label1] ()
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label1[Unit]: <empty>
+       |                    val x: String = "World"
+       |                    println("Hello")
+       |                    println(x)
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](2))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    ()
+       |                  case 2 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    ()
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |            println("End")
+       |            10
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineNoDependantSuspensions =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                      new continuations.SafeContinuation[Boolean](
+       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
+       |                      , continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label1] ()
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label1[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    val safeContinuation: continuations.SafeContinuation[String] = 
+       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
+       |                        , 
+       |                      continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label2] ()
+       |                    ()
+       |                  case 2 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label2[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    orThrow
+       |                  case 3 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $result
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineNoDependantSuspensionsWithCodeInside =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                      new continuations.SafeContinuation[Boolean](
+       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
+       |                      , continuations.Continuation.State.Undecided)
+       |                    println("Hi")
+       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label1] ()
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label1[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    val safeContinuation: continuations.SafeContinuation[String] = 
+       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
+       |                        , 
+       |                      continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                    println("World")
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label2] ()
+       |                    ()
+       |                  case 2 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label2[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    orThrow
+       |                  case 3 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $result
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
+  val expectedStateMachineNoDependantSuspensionsWithCodeBetween =
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package: 
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class 
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef = 
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    def program: Int = 
+       |      {
+       |        class program$foo$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion, 
+       |          $completion.context
+       |        ) {
+       |          var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |          var $label: Int = _
+       |          def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit
+       |             = 
+       |          ()
+       |          def $label_=(x$0: Int): Unit = ()
+       |          protected override def invokeSuspend(
+       |            result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |          ): Any | Null = 
+       |            {
+       |              this.$result = result
+       |              this.$label = this.$label.|(scala.Int.MinValue)
+       |              foo(this.asInstanceOf[continuations.Continuation[Int]])
+       |            }
+       |        }
+       |        def foo(completion: continuations.Continuation[Int]): 
+       |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |         = 
+       |          {
+       |            {
+       |              var $continuation: continuations.Continuation[Any] | Null = null
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    $continuation = x$0.asInstanceOf[program$foo$1]
+       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
+       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |                $continuation.asInstanceOf[program$foo$1].$result
+       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                {
+       |                  case 0 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    println("Start")
+       |                    val x: Int = 1
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                      new continuations.SafeContinuation[Boolean](
+       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
+       |                      , continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label1] ()
+       |                    ()
+       |                  case 1 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label1[Unit]: <empty>
+       |                    println("Hello")
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    val safeContinuation: continuations.SafeContinuation[String] = 
+       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
+       |                        , 
+       |                      continuations.Continuation.State.Undecided)
+       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    return[label2] ()
+       |                    ()
+       |                  case 2 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    label2[Unit]: <empty>
+       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                        continuations.Continuation.State.Undecided
+       |                      )
+       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                      safeContinuation.getOrThrow()
+       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                    orThrow
+       |                  case 3 => 
+       |                    if $result.!=(null) then 
+       |                      $result.fold[Unit](
+       |                        {
+       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                          closure($anonfun)
+       |                        }
+       |                      , 
+       |                        {
+       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                          closure($anonfun)
+       |                        }
+       |                      )
+       |                     else ()
+       |                    $result
+       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |                }
+       |            }
+       |          }
+       |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
+       |      }
+       |  }
+       |}
+       |""".stripMargin
+
   val expectedStateMachineOneParamOneDependantContinuation =
-      """|
-         |package continuations {
-         |  final lazy module val compileFromString$package:
-         |    continuations.compileFromString$package
-         |   = new continuations.compileFromString$package()
-         |  @SourceFile("compileFromString.scala") final module class
-         |    compileFromString$package
-         |  () extends Object() { this: continuations.compileFromString$package.type =>
-         |    private def writeReplace(): AnyRef =
-         |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-         |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
-         |      continuations.jvm.internal.ContinuationImpl
-         |    ($completion, $completion.context) {
-         |      var I$0: Any = _
-         |      var I$1: Any = _
-         |      def I$0_=(x$0: Any): Unit = ()
-         |      def I$1_=(x$0: Any): Unit = ()
-         |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-         |      var $label: Int = _
-         |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
-         |      def $label_=(x$0: Int): Unit = ()
-         |      protected override def invokeSuspend(
-         |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-         |      ): Any | Null =
-         |        {
-         |          this.$result = result
-         |          this.$label = this.$label.|(scala.Int.MinValue)
-         |          continuations.compileFromString$package.foo(null, this.asInstanceOf[continuations.Continuation[Int]])
-         |        }
-         |    }
-         |    def foo(x: Int, completion: continuations.Continuation[Int]):
-         |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-         |     =
-         |      {
-         |        var x##1: Int = x
-         |        var y: Int = null
-         |        {
-         |          var $continuation: continuations.Continuation[Any] | Null = null
-         |          completion match
-         |            {
-         |              case x$0 @ <empty> if
-         |                x$0.isInstanceOf[
-         |                  continuations.compileFromString$package.
-         |                    compileFromString$package$foo$1
-         |                ].&&(
-         |                  x$0.asInstanceOf[
-         |                    continuations.compileFromString$package.
-         |                      compileFromString$package$foo$1
-         |                  ].$label.&(scala.Int.MinValue).!=(0)
-         |                )
-         |               =>
-         |                $continuation =
-         |                  x$0.asInstanceOf[
-         |                    continuations.compileFromString$package.
-         |                      compileFromString$package$foo$1
-         |                  ]
-         |                $continuation.asInstanceOf[
-         |                  continuations.compileFromString$package.
-         |                    compileFromString$package$foo$1
-         |                ].$label =
-         |                  $continuation.asInstanceOf[
-         |                    continuations.compileFromString$package.
-         |                      compileFromString$package$foo$1
-         |                  ].$label.-(scala.Int.MinValue)
-         |              case _ =>
-         |                $continuation =
-         |                  new
-         |                    continuations.compileFromString$package.
-         |                      compileFromString$package$foo$1
-         |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-         |            }
-         |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-         |            $continuation.asInstanceOf[
-         |              continuations.compileFromString$package.
-         |                compileFromString$package$foo$1
-         |            ].$result
-         |          $continuation.asInstanceOf[
-         |            continuations.compileFromString$package.
-         |              compileFromString$package$foo$1
-         |          ].$label match
-         |            {
-         |              case 0 =>
-         |                if $result.!=(null) then
-         |                  $result.fold[Unit](
-         |                    {
-         |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
-         |                      closure($anonfun)
-         |                    }
-         |                  ,
-         |                    {
-         |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-         |                      closure($anonfun)
-         |                    }
-         |                  )
-         |                 else ()
-         |                $continuation.asInstanceOf[
-         |                  continuations.compileFromString$package.
-         |                    compileFromString$package$foo$1
-         |                ].I$0 = x##1
-         |                $continuation.asInstanceOf[
-         |                  continuations.compileFromString$package.
-         |                    compileFromString$package$foo$1
-         |                ].$label = 1
-         |                val safeContinuation: continuations.SafeContinuation[Int] =
-         |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
-         |                    continuations.Continuation.State.Undecided
-         |                  )
-         |                safeContinuation.resume(Right.apply[Nothing, Int](1))
-         |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
-         |                  safeContinuation.getOrThrow()
-         |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-         |                y = orThrow.asInstanceOf[Int]
-         |                ()
-         |              case 1 =>
-         |                x##1 =
-         |                  $continuation.asInstanceOf[
-         |                    continuations.compileFromString$package.
-         |                      compileFromString$package$foo$1
-         |                  ].I$0
-         |                if $result.!=(null) then
-         |                  $result.fold[Unit](
-         |                    {
-         |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
-         |                      closure($anonfun)
-         |                    }
-         |                  ,
-         |                    {
-         |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-         |                      closure($anonfun)
-         |                    }
-         |                  )
-         |                 else ()
-         |                y = $result.asInstanceOf[Int]
-         |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-         |            }
-         |        }
-         |        x##1.+(y)
-         |      }
-         |  }
-         |}
+    """|
+       |package continuations {
+       |  final lazy module val compileFromString$package:
+       |    continuations.compileFromString$package
+       |   = new continuations.compileFromString$package()
+       |  @SourceFile("compileFromString.scala") final module class
+       |    compileFromString$package
+       |  () extends Object() { this: continuations.compileFromString$package.type =>
+       |    private def writeReplace(): AnyRef =
+       |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+       |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
+       |      continuations.jvm.internal.ContinuationImpl
+       |    ($completion, $completion.context) {
+       |      var I$0: Any = _
+       |      var I$1: Any = _
+       |      def I$0_=(x$0: Any): Unit = ()
+       |      def I$1_=(x$0: Any): Unit = ()
+       |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+       |      var $label: Int = _
+       |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+       |      def $label_=(x$0: Int): Unit = ()
+       |      protected override def invokeSuspend(
+       |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+       |      ): Any | Null =
+       |        {
+       |          this.$result = result
+       |          this.$label = this.$label.|(scala.Int.MinValue)
+       |          continuations.compileFromString$package.foo(null, this.asInstanceOf[continuations.Continuation[Int]])
+       |        }
+       |    }
+       |    def foo(x: Int, completion: continuations.Continuation[Int]):
+       |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+       |     =
+       |      {
+       |        var x##1: Int = x
+       |        var y: Int = null
+       |        {
+       |          var $continuation: continuations.Continuation[Any] | Null = null
+       |          completion match
+       |            {
+       |              case x$0 @ <empty> if
+       |                x$0.isInstanceOf[
+       |                  continuations.compileFromString$package.
+       |                    compileFromString$package$foo$1
+       |                ].&&(
+       |                  x$0.asInstanceOf[
+       |                    continuations.compileFromString$package.
+       |                      compileFromString$package$foo$1
+       |                  ].$label.&(scala.Int.MinValue).!=(0)
+       |                )
+       |               =>
+       |                $continuation =
+       |                  x$0.asInstanceOf[
+       |                    continuations.compileFromString$package.
+       |                      compileFromString$package$foo$1
+       |                  ]
+       |                $continuation.asInstanceOf[
+       |                  continuations.compileFromString$package.
+       |                    compileFromString$package$foo$1
+       |                ].$label =
+       |                  $continuation.asInstanceOf[
+       |                    continuations.compileFromString$package.
+       |                      compileFromString$package$foo$1
+       |                  ].$label.-(scala.Int.MinValue)
+       |              case _ =>
+       |                $continuation =
+       |                  new
+       |                    continuations.compileFromString$package.
+       |                      compileFromString$package$foo$1
+       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |            }
+       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+       |            $continuation.asInstanceOf[
+       |              continuations.compileFromString$package.
+       |                compileFromString$package$foo$1
+       |            ].$result
+       |          $continuation.asInstanceOf[
+       |            continuations.compileFromString$package.
+       |              compileFromString$package$foo$1
+       |          ].$label match
+       |            {
+       |              case 0 =>
+       |                if $result.!=(null) then
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  ,
+       |                    {
+       |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
+       |                $continuation.asInstanceOf[
+       |                  continuations.compileFromString$package.
+       |                    compileFromString$package$foo$1
+       |                ].I$0 = x##1
+       |                $continuation.asInstanceOf[
+       |                  continuations.compileFromString$package.
+       |                    compileFromString$package$foo$1
+       |                ].$label = 1
+       |                val safeContinuation: continuations.SafeContinuation[Int] =
+       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+       |                    continuations.Continuation.State.Undecided
+       |                  )
+       |                safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+       |                  safeContinuation.getOrThrow()
+       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                y = orThrow.asInstanceOf[Int]
+       |                ()
+       |              case 1 =>
+       |                x##1 =
+       |                  $continuation.asInstanceOf[
+       |                    continuations.compileFromString$package.
+       |                      compileFromString$package$foo$1
+       |                  ].I$0
+       |                if $result.!=(null) then
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  ,
+       |                    {
+       |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
+       |                y = $result.asInstanceOf[Int]
+       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |            }
+       |        }
+       |        x##1.+(y)
+       |      }
+       |  }
+       |}
          """.stripMargin
-  // format: on
 
   val expectedStateMachineOneParamOneNoDependantContinuation =
     """

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -1,6 +1,6 @@
 package continuations
 
-trait ContinuationsPluginFixtures {
+trait StateMachineFixtures {
   // format: off
   val expectedStateMachineOneParamOneDependantContinuation =
       """|
@@ -292,146 +292,146 @@ trait ContinuationsPluginFixtures {
       |""".stripMargin
 
   val expectedStateMachineNoParamOneNoDependantContinuationCodeBeforeUsedAfter =
-      """
-        |package continuations {
-        |  final lazy module val compileFromString$package:
-        |    continuations.compileFromString$package
-        |   = new continuations.compileFromString$package()
-        |  @SourceFile("compileFromString.scala") final module class
-        |    compileFromString$package
-        |  () extends Object() { this: continuations.compileFromString$package.type =>
-        |    private def writeReplace(): AnyRef =
-        |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-        |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
-        |      continuations.jvm.internal.ContinuationImpl
-        |    ($completion, $completion.context) {
-        |      var I$0: Any = _
-        |      def I$0_=(x$0: Any): Unit = ()
-        |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
-        |      var $label: Int = _
-        |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
-        |      def $label_=(x$0: Int): Unit = ()
-        |      protected override def invokeSuspend(
-        |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
-        |      ): Any | Null =
-        |        {
-        |          this.$result = result
-        |          this.$label = this.$label.|(scala.Int.MinValue)
-        |          continuations.compileFromString$package.foo(this.asInstanceOf[continuations.Continuation[Int]])
-        |        }
-        |    }
-        |    def foo(completion: continuations.Continuation[Int]):
-        |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
-        |     =
-        |      {
-        |        var xx: Int = null
-        |        {
-        |          var $continuation: continuations.Continuation[Any] | Null = null
-        |          completion match
-        |            {
-        |              case x$0 @ <empty> if
-        |                x$0.isInstanceOf[
-        |                  continuations.compileFromString$package.
-        |                    compileFromString$package$foo$1
-        |                ].&&(
-        |                  x$0.asInstanceOf[
-        |                    continuations.compileFromString$package.
-        |                      compileFromString$package$foo$1
-        |                  ].$label.&(scala.Int.MinValue).!=(0)
-        |                )
-        |               =>
-        |                $continuation =
-        |                  x$0.asInstanceOf[
-        |                    continuations.compileFromString$package.
-        |                      compileFromString$package$foo$1
-        |                  ]
-        |                $continuation.asInstanceOf[
-        |                  continuations.compileFromString$package.
-        |                    compileFromString$package$foo$1
-        |                ].$label =
-        |                  $continuation.asInstanceOf[
-        |                    continuations.compileFromString$package.
-        |                      compileFromString$package$foo$1
-        |                  ].$label.-(scala.Int.MinValue)
-        |              case _ =>
-        |                $continuation =
-        |                  new
-        |                    continuations.compileFromString$package.
-        |                      compileFromString$package$foo$1
-        |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-        |            }
-        |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-        |            $continuation.asInstanceOf[
-        |              continuations.compileFromString$package.
-        |                compileFromString$package$foo$1
-        |            ].$result
-        |          $continuation.asInstanceOf[
-        |            continuations.compileFromString$package.
-        |              compileFromString$package$foo$1
-        |          ].$label match
-        |            {
-        |              case 0 =>
-        |                if $result.!=(null) then
-        |                  $result.fold[Unit](
-        |                    {
-        |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
-        |                      closure($anonfun)
-        |                    }
-        |                  ,
-        |                    {
-        |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-        |                      closure($anonfun)
-        |                    }
-        |                  )
-        |                 else ()
-        |                xx = 111
-        |                println(xx)
-        |                $continuation.asInstanceOf[
-        |                  continuations.compileFromString$package.
-        |                    compileFromString$package$foo$1
-        |                ].I$0 = xx
-        |                $continuation.asInstanceOf[
-        |                  continuations.compileFromString$package.
-        |                    compileFromString$package$foo$1
-        |                ].$label = 1
-        |                val safeContinuation: continuations.SafeContinuation[Int] =
-        |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
-        |                    continuations.Continuation.State.Undecided
-        |                  )
-        |                safeContinuation.resume(Right.apply[Nothing, Int](10))
-        |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
-        |                  safeContinuation.getOrThrow()
-        |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-        |                ()
-        |              case 1 =>
-        |                xx =
-        |                  $continuation.asInstanceOf[
-        |                    continuations.compileFromString$package.
-        |                      compileFromString$package$foo$1
-        |                  ].I$0
-        |                if $result.!=(null) then
-        |                  $result.fold[Unit](
-        |                    {
-        |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
-        |                      closure($anonfun)
-        |                    }
-        |                  ,
-        |                    {
-        |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-        |                      closure($anonfun)
-        |                    }
-        |                  )
-        |                 else ()
-        |                ()
-        |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-        |            }
-        |        }
-        |        xx
-        |      }
-        |  }
-        |}
-        |""".stripMargin
-      
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$foo$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.foo(this.asInstanceOf[continuations.Continuation[Int]])
+      |        }
+      |    }
+      |    def foo(completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var xx: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$foo$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$foo$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                xx = 111
+      |                println(xx)
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].I$0 = xx
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$foo$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](10))
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                ()
+      |              case 1 =>
+      |                xx =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].I$0
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                ()
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        xx
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+
   val expectedStateMachineManyDependantContinuations =
     """
       package continuations {
@@ -1101,6 +1101,218 @@ trait ContinuationsPluginFixtures {
       |        }
       |        println(xx)
       |        xx.+(qq##1).+(zz).+(pp).+(tt)
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+
+  val expectedStateMachineWithDependantAndNoDependantContinuationAtTheEnd =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      var I$1: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      def I$1_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(null,
+      |            this.asInstanceOf[continuations.Continuation[Int]]
+      |          )
+      |        }
+      |    }
+      |    def fooTest(x: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var x##1: Int = x
+      |        var y: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                println("Hello")
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      println("World")
+      |                      1
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                y = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                x##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                y = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                val z: Int = 1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = y
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                val w: String = "World"
+      |                println("Hello")
+      |                safeContinuation.resume(
+      |                  Right.apply[Nothing, Int](
+      |                    {
+      |                      println(z)
+      |                      x##1
+      |                    }
+      |                  )
+      |                )
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                ()
+      |              case 2 =>
+      |                x##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                y =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                ()
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        val tt: Int = 2
+      |        x##1.+(y).+(tt)
       |      }
       |  }
       |}

--- a/continuationsPlugin/src/test/scala/continuations/SuspensionPointsSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/SuspensionPointsSuite.scala
@@ -13,9 +13,9 @@ class SuspensionPointsSuite extends FunSuite, CompilerFixtures, Trees {
       case (given Context, tree) =>
         val obtained = SuspensionPoints.unapplySeq(tree).get
         assert(
-          obtained.points.size == 2 &&
-            obtained.points.headOption.exists { case vd: ValDef => vd.name.show == "y" } &&
-            obtained.points.lastOption.exists {
+          obtained.size == 2 &&
+            obtained.headOption.exists { case vd: ValDef => vd.name.show == "y" } &&
+            obtained.lastOption.exists {
               case Inlined(call, _, _) => call.symbol.matches(suspendContinuationMethod.symbol)
             })
     }
@@ -25,7 +25,7 @@ class SuspensionPointsSuite extends FunSuite, CompilerFixtures, Trees {
       case (given Context, tree) =>
         val obtained = SuspensionPoints.unapplySeq(tree).get
         assert(
-          obtained.points.size == 1 &&
-            obtained.points.headOption.exists { case vd: ValDef => vd.name.show == "y" })
+          obtained.size == 1 &&
+            obtained.headOption.exists { case vd: ValDef => vd.name.show == "y" })
     }
 }

--- a/continuationsPlugin/src/test/scala/continuations/SuspensionPointsSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/SuspensionPointsSuite.scala
@@ -6,38 +6,26 @@ import munit.FunSuite
 
 class SuspensionPointsSuite extends FunSuite, CompilerFixtures, Trees {
 
-  continutationsContextAndSuspendingSingleArityWithDependentNonSuspendingCalculation.test(
-    "It should extract the val y valdef suspension point from the tree") {
-    case (given Context, tree) =>
-      val obtained = SuspensionPoints.unapplySeq(tree).get
-      assert(
-        obtained.withValSize == 1 && obtained.nonValSize == 0 &&
-          obtained.withVal.get.exists(_.existsSubTree { t => t.symbol.name.show == "y" }))
-  }
+  continutationsContextAndSuspendingSingleArityWithDependentNonSuspendingAndNonDependentCalculation
+    .test(
+      "It should extract the val y valdef suspension point and a suspension point that is not " +
+        "assigned to a val from the tree, keeping the order") {
+      case (given Context, tree) =>
+        val obtained = SuspensionPoints.unapplySeq(tree).get
+        assert(
+          obtained.points.size == 2 &&
+            obtained.points.headOption.exists { case vd: ValDef => vd.name.show == "y" } &&
+            obtained.points.lastOption.exists {
+              case Inlined(call, _, _) => call.symbol.matches(suspendContinuationMethod.symbol)
+            })
+    }
 
   continutationsContextAndInlinedSuspendingSingleArityWithDependentNonSuspendingCalculation
     .test("It should extract the val y valdef suspension point from the tree while inlined") {
       case (given Context, tree) =>
         val obtained = SuspensionPoints.unapplySeq(tree).get
         assert(
-          obtained.withValSize == 1 && obtained.nonValSize == 0 &&
-            obtained.withVal.get.exists(_.existsSubTree { t => t.symbol.name.show == "y" }))
+          obtained.points.size == 1 &&
+            obtained.points.headOption.exists { case vd: ValDef => vd.name.show == "y" })
     }
-
-  continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
-    "It should extract suspension points from the tree that are not assigned to a val"
-  ) {
-    case (given Context, tree) =>
-      val obtained = SuspensionPoints.unapplySeq(tree).get
-
-      assert(
-        obtained.withValSize == 0 && obtained.nonValSize == 1 &&
-          obtained
-            .nonVal
-            .get
-            .exists(_.existsSubTree {
-              case Inlined(call, _, _) => call.symbol.matches(suspendContinuationMethod.symbol)
-              case _ => false
-            }))
-  }
 }

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -164,3 +164,17 @@ def programSuspendContinuationNoParamResumeIgnoreResult: Int =
     10
 
   fooTest()
+
+def programSuspendContinuationParamDependent: Int =
+  def fooTest(qq: Int)(using s: Suspend): Int =
+    val pp = 11
+    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
+    val ww = 13
+    val rr = "AAA"
+    val yy = s.suspendContinuation[String] { c => c.resume(Right { rr }) }
+    val tt = 100
+    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
+    println(xx)
+    xx + qq + zz + pp + tt + yy.length
+
+  fooTest(12)

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -173,7 +173,7 @@ def programSuspendContinuationParamDependent: Int =
     val rr = "AAA"
     val yy = s.suspendContinuation[String] { c => c.resume(Right { rr }) }
     val tt = 100
-    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
+    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 + xx }) }
     println(xx)
     xx + qq + zz + pp + tt + yy.length
 

--- a/continuationsPluginExample/src/main/scala/examples/Main.scala
+++ b/continuationsPluginExample/src/main/scala/examples/Main.scala
@@ -12,6 +12,7 @@ import continuations.jvm.internal.ContinuationImpl
   println(result3)
   val result4 = programSuspendContinuationNoParamResumeIgnoreResult
   println(result4)
+  println(programSuspendContinuationParamDependent)
 
 object main$handler extends (Continuation[Any | Null] => Any):
   override def apply($completion: Continuation[Any | Null]): Any =


### PR DESCRIPTION
this includes chained suspendConts as well because it came for free, for the state machine it is another `val` that needs to be stored because it is being used later on