### PR TITLE
CU-865bm99yr - Compiler plugin: Fix calling a suspending function with generic params

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -83,8 +83,10 @@ class ContinuationsCallsPhase extends PluginPhase:
           case _ => false
         }
         .map {
-          case Apply(_, args) =>
+          case Apply(fun, args) if !fun.isInstanceOf[Select] =>
             args.filterNot(_.tpe.hasClassSymbol(requiredClass(suspendFullName)))
+          case _ =>
+            List.empty
         }
         .reverse
         .flatten :+ continuation

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -2231,4 +2231,92 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures {
           assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expectedSuspend)
       }
   }
+
+  compilerContextWithContinuationsPlugin.test(
+    "it should update the call site for a simple suspended def with a generic param ") {
+    case given Context =>
+      val source =
+        """|
+           |package continuations
+           |
+           |def program = {
+           |  case class Foo(i: Int)
+           |  def foo[A](a: A)(using Suspend): A = a
+           |  foo(Foo(1))
+           |}
+           |""".stripMargin
+
+      // format: off
+      val expected =
+        """|
+           |package continuations {
+           |  final lazy module val compileFromString$package: 
+           |    continuations.compileFromString$package
+           |   = new continuations.compileFromString$package()
+           |  @SourceFile("compileFromString.scala") final module class 
+           |    compileFromString$package
+           |  () extends Object() { this: continuations.compileFromString$package.type =>
+           |    private def writeReplace(): AnyRef = 
+           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+           |    def program: Object = 
+           |      {
+           |        case class Foo(i: Int) extends Object(), _root_.scala.Product, _root_.scala.Serializable {
+           |          override def hashCode(): Int = 
+           |            {
+           |              var acc: Int = -889275714
+           |              acc = scala.runtime.Statics#mix(acc, this.productPrefix.hashCode())
+           |              acc = scala.runtime.Statics#mix(acc, Foo.this.i)
+           |              scala.runtime.Statics#finalizeHash(acc, 1)
+           |            }
+           |          override def equals(x$0: Any): Boolean = 
+           |            this.eq(x$0.$asInstanceOf[Object]).||(
+           |              x$0 match 
+           |                {
+           |                  case x$0 @ _:Foo @unchecked => this.i.==(x$0.i).&&(x$0.canEqual(this))
+           |                  case _ => false
+           |                }
+           |            )
+           |          override def toString(): String = scala.runtime.ScalaRunTime._toString(this)
+           |          override def canEqual(that: Any): Boolean = that.isInstanceOf[Foo @unchecked]
+           |          override def productArity: Int = 1
+           |          override def productPrefix: String = "Foo"
+           |          override def productElement(n: Int): Any = 
+           |            n match 
+           |              {
+           |                case 0 => this._1
+           |                case _ => throw new IndexOutOfBoundsException(n.toString())
+           |              }
+           |          override def productElementName(n: Int): String = 
+           |            n match 
+           |              {
+           |                case 0 => "i"
+           |                case _ => throw new IndexOutOfBoundsException(n.toString())
+           |              }
+           |          val i: Int
+           |          def copy(i: Int): Foo = new Foo(i)
+           |          def copy$default$1: Int @uncheckedVariance = Foo.this.i
+           |          def _1: Int = this.i
+           |        }
+           |        final lazy module val Foo: Foo = new Foo()
+           |        final module class Foo() extends AnyRef(), scala.deriving.Mirror.Product { this: Foo.type =>
+           |          def apply(i: Int): Foo = new Foo(i)
+           |          def unapply(x$1: Foo): Foo = x$1
+           |          override def toString: String = "Foo"
+           |          type MirroredMonoType = Foo
+           |          def fromProduct(x$0: Product): continuations.compileFromString$package.Foo.MirroredMonoType = 
+           |            new Foo(x$0.productElement(0).$asInstanceOf[Int])
+           |        }
+           |        def foo(a: A, completion: continuations.Continuation[A | Any]): Any = a
+           |        foo(Foo.apply(1), continuations.jvm.internal.ContinuationStub.contImpl):Object & Product & Serializable
+           |      }
+           |  }
+           |}
+           |""".stripMargin
+      // format: on
+
+      checkContinuations(source) {
+        case (tree, _) =>
+          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+      }
+  }
 }


### PR DESCRIPTION
while looking at the scenarios for the demo we found with @pabloconde that this case was not working (it was working only for A == Int, String, etc). opening a separate fix for it  instead of having it as part of the demo PR