### PR TITLE
CU-43w1jzc - Compiler Plugin: Set ownership if there are vals only in resume body

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -71,14 +71,15 @@ object DefDefTransforms extends TreesChecks:
         }
 
     val removedAnonFunc: List[Symbol] = suspendContinuationBody
-      .filter(t =>
-        t.symbol.exists &&
-          t.symbol.owner.isAnonymousFunction &&
-          t.symbol
-            .owner
-            .paramSymss
-            .flatten
-            .exists(_.info.hasClassSymbol(requiredClass(continuationFullName))))
+      .flatMap(
+        _.filterSubTrees(t =>
+          t.symbol.exists &&
+            t.symbol.owner.isAnonymousFunction &&
+            t.symbol
+              .owner
+              .paramSymss
+              .flatten
+              .exists(_.info.hasClassSymbol(requiredClass(continuationFullName)))))
       .map(_.symbol.owner)
       .distinct
 

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -178,3 +178,16 @@ def programSuspendContinuationParamDependent: Int =
     xx + qq + zz + pp + tt + yy.length
 
   fooTest(12)
+
+def programSuspendContinuationResumeVals: Int =
+  def fooTest()(using Suspend): Int =
+    summon[Suspend].suspendContinuation[Int] { c =>
+      c.resume {
+        println("Hello")
+        val x = 1
+        val y = 1
+        Right(x + y)
+      }
+    }
+
+  fooTest()


### PR DESCRIPTION
Looking at the demo cases I found that one was not working because the vals' ownership was not being updated. since it is a small fix I open a PR on the story that this functionality was implemented initially