### PR TITLE
CU-86778gnje - Compiler Plugin: Verify that chained continuations with 1 param work

### DIFF
--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -2906,4 +2906,430 @@ trait StateMachineFixtures {
       |  }
       |}
       |""".stripMargin
+
+  val expectedStateMachineChainedSuspendContinuationsOneParameter =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      var I$1: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      def I$1_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(null,
+      |            this.asInstanceOf[continuations.Continuation[Int]]
+      |          )
+      |        }
+      |    }
+      |    def fooTest(x: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var x##1: Int = x
+      |        var y: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(1)))
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                y = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                x##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                y = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = y
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](y.+(1)))
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                orThrow
+      |              case 2 =>
+      |                x##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                y =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                $result
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |      }
+      |  }
+      |}
+      |""".stripMargin
+
+  val expectedStateMachineChainedSuspendContinuationsOneParameterAndVals =
+    """
+      |package continuations {
+      |  final lazy module val compileFromString$package:
+      |    continuations.compileFromString$package
+      |   = new continuations.compileFromString$package()
+      |  @SourceFile("compileFromString.scala") final module class
+      |    compileFromString$package
+      |  () extends Object() { this: continuations.compileFromString$package.type =>
+      |    private def writeReplace(): AnyRef =
+      |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+      |    class compileFromString$package$fooTest$1($completion: continuations.Continuation[Any | Null]) extends
+      |      continuations.jvm.internal.ContinuationImpl
+      |    ($completion, $completion.context) {
+      |      var I$0: Any = _
+      |      var I$1: Any = _
+      |      var I$2: Any = _
+      |      var I$3: Any = _
+      |      var I$4: Any = _
+      |      def I$0_=(x$0: Any): Unit = ()
+      |      def I$1_=(x$0: Any): Unit = ()
+      |      def I$2_=(x$0: Any): Unit = ()
+      |      def I$3_=(x$0: Any): Unit = ()
+      |      def I$4_=(x$0: Any): Unit = ()
+      |      var $result: Either[Throwable, Any | Null | continuations.Continuation.State.Suspended.type] = _
+      |      var $label: Int = _
+      |      def $result_=(x$0: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]): Unit = ()
+      |      def $label_=(x$0: Int): Unit = ()
+      |      protected override def invokeSuspend(
+      |        result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)]
+      |      ): Any | Null =
+      |        {
+      |          this.$result = result
+      |          this.$label = this.$label.|(scala.Int.MinValue)
+      |          continuations.compileFromString$package.fooTest(null,
+      |            this.asInstanceOf[continuations.Continuation[Int]]
+      |          )
+      |        }
+      |    }
+      |    def fooTest(x: Int, completion: continuations.Continuation[Int]):
+      |      Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
+      |     =
+      |      {
+      |        var x##1: Int = x
+      |        var q: Int = null
+      |        var y: Int = null
+      |        var p: Int = null
+      |        var z: Int = null
+      |        {
+      |          var $continuation: continuations.Continuation[Any] | Null = null
+      |          completion match
+      |            {
+      |              case x$0 @ <empty> if
+      |                x$0.isInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].&&(
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.&(scala.Int.MinValue).!=(0)
+      |                )
+      |               =>
+      |                $continuation =
+      |                  x$0.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ]
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].$label.-(scala.Int.MinValue)
+      |              case _ =>
+      |                $continuation =
+      |                  new
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |            }
+      |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
+      |            $continuation.asInstanceOf[
+      |              continuations.compileFromString$package.
+      |                compileFromString$package$fooTest$1
+      |            ].$result
+      |          $continuation.asInstanceOf[
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |          ].$label match
+      |            {
+      |              case 0 =>
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                q = 2
+      |                val w: Int = 3
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = q
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 1
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(w)))
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                y = orThrow.asInstanceOf[Int]
+      |                return[label1] ()
+      |                ()
+      |              case 1 =>
+      |                x##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                q =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                y = $result.asInstanceOf[Int]
+      |                label1[Unit]: <empty>
+      |                p = 1
+      |                val t: Int = 1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$0 = x##1
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$1 = q
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$2 = y
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].I$3 = p
+      |                $continuation.asInstanceOf[
+      |                  continuations.compileFromString$package.
+      |                    compileFromString$package$fooTest$1
+      |                ].$label = 2
+      |                val safeContinuation: continuations.SafeContinuation[Int] =
+      |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
+      |                    continuations.Continuation.State.Undecided
+      |                  )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](y.+(q).+(x##1)))
+      |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+      |                  safeContinuation.getOrThrow()
+      |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+      |                z = orThrow.asInstanceOf[Int]
+      |                ()
+      |              case 2 =>
+      |                x##1 =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$0
+      |                q =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$1
+      |                y =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$2
+      |                p =
+      |                  $continuation.asInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].I$3
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  ,
+      |                    {
+      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
+      |                z = $result.asInstanceOf[Int]
+      |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+      |            }
+      |        }
+      |        z.+(y).+(p)
+      |      }
+      |  }
+      |}
+      |""".stripMargin
 }


### PR DESCRIPTION
the functionality has been added already as part of the [dependent continuations](https://github.com/47deg/TBD/pull/68) since it follows the same logic