### PR TITLE
Introduce a BlockFlattener transformation.

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -28,7 +28,7 @@ object DefDefTransforms extends TreesChecks:
   def flattenBlock(b: tpd.Block)(using Context): tpd.Block =
     b match {
       case bb @ Trees.Block(Nil, _: tpd.Closure) => bb
-      case Trees.Block(Nil, bb @ tpd.Block(_, _)) => bb
+      case Trees.Block(Nil, bb @ tpd.Block(_, _)) => flattenBlock(bb)
       case b => b
     }
 

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -25,6 +25,8 @@ import scala.collection.mutable.ListBuffer
 
 object DefDefTransforms extends TreesChecks:
 
+  def flattenBlock(b: tpd.Block): tpd.Block = ???
+
   private def generateCompletion(owner: Symbol, returnType: Type)(using Context): Symbol =
     newSymbol(
       owner,

--- a/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
@@ -915,6 +915,14 @@ trait CompilerFixtures { self: FunSuite =>
     setup = _ => { Block(List(), Block(List(), Literal(Constant(1)))) },
     teardown = _ => ())
 
+  val expectedFlattenedBlock = FunFixture[Context ?=> Block](
+    setup = _ => Block(List(), Literal(Constant(1))),
+    teardown = _ => ())
+
+  val recursiveNestedBlock = FunFixture[Context ?=> Block](
+    setup = _ => { Block(Nil, (Block(Nil, Block(Nil, Literal(Constant(1)))))) },
+    teardown = _ => ())
+
   val unflattenableNestedBlock = FunFixture[Context ?=> Block](
     setup = _ => {
       Block(
@@ -930,10 +938,19 @@ trait CompilerFixtures { self: FunSuite =>
   )
 
   val continuationsContextAndFlattenableNestedBlock =
-    FunFixture.map2(compilerContextWithContinuationsPlugin, flattenableNestedBlock)
+    FunFixture.map3(
+      compilerContextWithContinuationsPlugin,
+      flattenableNestedBlock,
+      expectedFlattenedBlock)
 
   val continuationsContextAndUnflattenableNestedBlock =
     FunFixture.map2(compilerContextWithContinuationsPlugin, unflattenableNestedBlock)
+
+  val continuationsContextAndFlattenableRecursiveBlock =
+    FunFixture.map3(
+      compilerContextWithContinuationsPlugin,
+      recursiveNestedBlock,
+      expectedFlattenedBlock)
 
   private lazy val suspend: Context ?=> Symbol =
     Symbols.requiredClass("continuations.Suspend")

--- a/continuationsPlugin/src/test/scala/continuations/FlattenBlockSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/FlattenBlockSuite.scala
@@ -11,11 +11,10 @@ import munit.FunSuite
 class FlattenBlockSuite extends FunSuite, CompilerFixtures {
 
   continuationsContextAndFlattenableNestedBlock.test("It should flatten nested blocks") {
-    case (given Context, sourceBlock) =>
+    case (given Context, sourceBlock, expectedTree) =>
       val sourceTree =
         DefDefTransforms.flattenBlock(sourceBlock).show
-      val expectedTree = Block(List(), Literal(Constant(1))).show
-      assertNoDiff(sourceTree, expectedTree)
+      assertNoDiff(sourceTree, expectedTree.show)
   }
 
   continuationsContextAndUnflattenableNestedBlock.test(
@@ -30,6 +29,15 @@ class FlattenBlockSuite extends FunSuite, CompilerFixtures {
       val sourceTree =
         DefDefTransforms.flattenBlock(sourceBlock).show
       assertNoDiff(sourceTree, expectedTree)
+  }
+
+  continuationsContextAndFlattenableRecursiveBlock.test(
+    "It should flatten blocks recursively") {
+    case (given Context, recursiveSourceBlock, expectedTree) =>
+      val sourceTree =
+        DefDefTransforms.flattenBlock(recursiveSourceBlock).show
+      assertNoDiff(sourceTree, expectedTree.show)
+
   }
 
 }

--- a/continuationsPlugin/src/test/scala/continuations/FlattenBlockSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/FlattenBlockSuite.scala
@@ -1,0 +1,35 @@
+package continuations
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Types.MethodType
+import munit.FunSuite
+
+class FlattenBlockSuite extends FunSuite, CompilerFixtures {
+
+  continuationsContextAndFlattenableNestedBlock.test("It should flatten nested blocks") {
+    case (given Context, sourceBlock) =>
+      val sourceTree =
+        DefDefTransforms.flattenBlock(sourceBlock).show
+      val expectedTree = Block(List(), Literal(Constant(1))).show
+      assertNoDiff(sourceTree, expectedTree)
+  }
+
+  continuationsContextAndUnflattenableNestedBlock.test(
+    "It should not flatten nested closure blocks") {
+    case (given Context, sourceBlock) =>
+      val expectedTree = Block(
+        List(
+          Lambda(
+            MethodType.apply(List(defn.ThrowableType))(_ => defn.NothingType),
+            trees => Throw(trees.head))),
+        Literal(Constant(1))).show
+      val sourceTree =
+        DefDefTransforms.flattenBlock(sourceBlock).show
+      assertNoDiff(sourceTree, expectedTree)
+  }
+
+}

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -697,113 +697,111 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0.asInstanceOf[program$foo$1]
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
-       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
-       |                {
-       |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
+       |            var $continuation: continuations.Continuation[Any] | Null = null
+       |            completion match 
+       |              {
+       |                case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                  $continuation = x$0.asInstanceOf[program$foo$1]
+       |                  $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |              }
+       |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |              $continuation.asInstanceOf[program$foo$1].$result
+       |            $continuation.asInstanceOf[program$foo$1].$label match 
+       |              {
+       |                case 0 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
        |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-       |                      new continuations.SafeContinuation[Boolean](
-       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-       |                      , continuations.Continuation.State.Undecided)
-       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    return[label1] ()
-       |                    ()
-       |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    label1[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-       |                    val safeContinuation: continuations.SafeContinuation[String] = 
-       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-       |                        , 
-       |                      continuations.Continuation.State.Undecided)
-       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    return[label2] ()
-       |                    ()
-       |                  case 2 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    label2[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-       |                        continuations.Continuation.State.Undecided
-       |                      )
-       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    orThrow
-       |                  case 3 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    $result
-       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-       |                }
-       |            }
+       |                    continuations.Continuation.State.Undecided)
+       |                  safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  return[label1] ()
+       |                  ()
+       |                case 1 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  label1[Unit]: <empty>
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                  val safeContinuation: continuations.SafeContinuation[String] = 
+       |                    new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(), 
+       |                      continuations.Continuation.State.Undecided
+       |                    )
+       |                  safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  return[label2] ()
+       |                  ()
+       |                case 2 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  label2[Unit]: <empty>
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                  val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                    new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                      continuations.Continuation.State.Undecided
+       |                    )
+       |                  safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  orThrow
+       |                case 3 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  $result
+       |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |              }
        |          }
        |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
        |      }
@@ -846,115 +844,113 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0.asInstanceOf[program$foo$1]
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
-       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
-       |                {
-       |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
+       |            var $continuation: continuations.Continuation[Any] | Null = null
+       |            completion match 
+       |              {
+       |                case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                  $continuation = x$0.asInstanceOf[program$foo$1]
+       |                  $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |              }
+       |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |              $continuation.asInstanceOf[program$foo$1].$result
+       |            $continuation.asInstanceOf[program$foo$1].$label match 
+       |              {
+       |                case 0 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
        |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-       |                      new continuations.SafeContinuation[Boolean](
-       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-       |                      , continuations.Continuation.State.Undecided)
-       |                    println("Hi")
-       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    return[label1] ()
-       |                    ()
-       |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    label1[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-       |                    val safeContinuation: continuations.SafeContinuation[String] = 
-       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-       |                        , 
-       |                      continuations.Continuation.State.Undecided)
-       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-       |                    println("World")
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    return[label2] ()
-       |                    ()
-       |                  case 2 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    label2[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-       |                        continuations.Continuation.State.Undecided
-       |                      )
-       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    orThrow
-       |                  case 3 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    $result
-       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-       |                }
-       |            }
+       |                    continuations.Continuation.State.Undecided)
+       |                  println("Hi")
+       |                  safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  return[label1] ()
+       |                  ()
+       |                case 1 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  label1[Unit]: <empty>
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                  val safeContinuation: continuations.SafeContinuation[String] = 
+       |                    new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(), 
+       |                      continuations.Continuation.State.Undecided
+       |                    )
+       |                  safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                  println("World")
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  return[label2] ()
+       |                  ()
+       |                case 2 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  label2[Unit]: <empty>
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                  val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                    new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                      continuations.Continuation.State.Undecided
+       |                    )
+       |                  safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  orThrow
+       |                case 3 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  $result
+       |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |              }
        |          }
        |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
        |      }
@@ -997,116 +993,114 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0.asInstanceOf[program$foo$1]
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
-       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
-       |                {
-       |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
+       |            var $continuation: continuations.Continuation[Any] | Null = null
+       |            completion match 
+       |              {
+       |                case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                  $continuation = x$0.asInstanceOf[program$foo$1]
+       |                  $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |              }
+       |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
+       |              $continuation.asInstanceOf[program$foo$1].$result
+       |            $continuation.asInstanceOf[program$foo$1].$label match 
+       |              {
+       |                case 0 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  println("Start")
+       |                  val x: Int = 1
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
+       |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
        |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    println("Start")
-       |                    val x: Int = 1
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
-       |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
-       |                      new continuations.SafeContinuation[Boolean](
-       |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
-       |                      , continuations.Continuation.State.Undecided)
-       |                    safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    return[label1] ()
-       |                    ()
-       |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    label1[Unit]: <empty>
-       |                    println("Hello")
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
-       |                    val safeContinuation: continuations.SafeContinuation[String] = 
-       |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
-       |                        , 
-       |                      continuations.Continuation.State.Undecided)
-       |                    safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    return[label2] ()
-       |                    ()
-       |                  case 2 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    label2[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
-       |                    val safeContinuation: continuations.SafeContinuation[Int] = 
-       |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
-       |                        continuations.Continuation.State.Undecided
-       |                      )
-       |                    safeContinuation.resume(Right.apply[Nothing, Int](1))
-       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
-       |                      safeContinuation.getOrThrow()
-       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-       |                    orThrow
-       |                  case 3 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
-       |                    $result
-       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
-       |                }
-       |            }
+       |                    continuations.Continuation.State.Undecided)
+       |                  safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  return[label1] ()
+       |                  ()
+       |                case 1 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  label1[Unit]: <empty>
+       |                  println("Hello")
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                  val safeContinuation: continuations.SafeContinuation[String] = 
+       |                    new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(), 
+       |                      continuations.Continuation.State.Undecided
+       |                    )
+       |                  safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  return[label2] ()
+       |                  ()
+       |                case 2 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  label2[Unit]: <empty>
+       |                  $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                  val safeContinuation: continuations.SafeContinuation[Int] = 
+       |                    new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
+       |                      continuations.Continuation.State.Undecided
+       |                    )
+       |                  safeContinuation.resume(Right.apply[Nothing, Int](1))
+       |                  val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
+       |                    safeContinuation.getOrThrow()
+       |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+       |                  orThrow
+       |                case 3 => 
+       |                  if $result.!=(null) then 
+       |                    $result.fold[Unit](
+       |                      {
+       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                        closure($anonfun)
+       |                      }
+       |                    , 
+       |                      {
+       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                        closure($anonfun)
+       |                      }
+       |                    )
+       |                   else ()
+       |                  $result
+       |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
+       |              }
        |          }
        |        foo(continuations.jvm.internal.ContinuationStub.contImpl)
        |      }

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -1362,13 +1362,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Unit](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Unit]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Unit](
-      |                    {
-      |                      println(qq##1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Unit](println(qq##1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -1673,13 +1667,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      qq##1.-(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](qq##1.-(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -1738,13 +1726,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, String](
-      |                    {
-      |                      rr
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, String](rr))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -1820,13 +1802,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      ww.-(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](ww.-(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2014,13 +1990,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      qq##1.-(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](qq##1.-(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2079,13 +2049,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, String](
-      |                    {
-      |                      rr
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, String](rr))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2155,13 +2119,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      ww.-(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](ww.-(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2530,13 +2488,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      1
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](1))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2571,13 +2523,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2728,13 +2674,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      1.+(z)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](1.+(z)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2783,13 +2723,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x.+(1).+(q##1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x.+(1).+(q##1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -2852,13 +2786,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x.+(w).+(1).+(j)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x.+(w).+(1).+(j)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -3450,13 +3378,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -3509,13 +3431,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -3688,13 +3604,7 @@ trait StateMachineFixtures {
       |                      new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A]($continuation)(),
       |                        continuations.Continuation.State.Undecided
       |                      )
-      |                    safeContinuation.resume(
-      |                      Right.apply[Nothing, A](
-      |                        {
-      |                          a##1
-      |                        }
-      |                      )
-      |                    )
+      |                    safeContinuation.resume(Right.apply[Nothing, A](a##1))
       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                      safeContinuation.getOrThrow()
       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -3947,13 +3857,7 @@ trait StateMachineFixtures {
       |                      new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A]($continuation)(),
       |                        continuations.Continuation.State.Undecided
       |                      )
-      |                    safeContinuation.resume(
-      |                      Right.apply[Nothing, A](
-      |                        {
-      |                          a##1
-      |                        }
-      |                      )
-      |                    )
+      |                    safeContinuation.resume(Right.apply[Nothing, A](a##1))
       |                    val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                      safeContinuation.getOrThrow()
       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4152,13 +4056,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4220,13 +4118,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4393,13 +4285,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4452,13 +4338,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4618,13 +4498,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4677,13 +4551,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4844,13 +4712,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -4903,13 +4765,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5070,13 +4926,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(w)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5129,13 +4979,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5297,13 +5141,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5356,13 +5194,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5524,13 +5356,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(w)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5583,13 +5409,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(1)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5758,13 +5578,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(w)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -5826,13 +5640,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6006,13 +5814,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(w)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6075,13 +5877,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6262,13 +6058,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6340,13 +6130,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(b).+(c)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(b).+(c)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6525,13 +6309,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6595,13 +6373,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(b)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(b)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6782,13 +6554,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -6861,13 +6627,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7053,13 +6813,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7132,13 +6886,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c).+(d)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7327,13 +7075,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7406,13 +7148,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c).+(d)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7603,13 +7339,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7682,13 +7412,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c).+(d)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7880,13 +7604,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -7959,13 +7677,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c).+(d)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -8157,13 +7869,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -8236,13 +7942,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c).+(d)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -8435,13 +8135,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      x##1.+(y##1).+(a)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
@@ -8514,13 +8208,7 @@ trait StateMachineFixtures {
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
       |                  )
-      |                safeContinuation.resume(
-      |                  Right.apply[Nothing, Int](
-      |                    {
-      |                      z.+(c).+(d)
-      |                    }
-      |                  )
-      |                )
+      |                safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
       |                val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
       |                  safeContinuation.getOrThrow()
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended


### PR DESCRIPTION
The generated code sometimes includes blocks within blocks within blocks, and there is no good reason to have that. So we add a BlockFlattener transformation to clean those up.

We define it as a class outside of any method to emphasize that the transformation is well stand-alone, and could very well be part of a general macro utility.