### PR TITLE
Refactor: turn matchers to predicates.

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/BodyHasSuspensionPoint.scala
+++ b/continuationsPlugin/src/main/scala/continuations/BodyHasSuspensionPoint.scala
@@ -16,11 +16,8 @@ private[continuations] object BodyHasSuspensionPoint extends TreesChecks:
    * @param defdef
    *   The method to match upon
    * @return
-   *   A [[scala.Some]] if the method has a using [[continuations.Suspend]] parameter and has a
-   *   suspended continuation in its method body, [[scala.None]] otherwise
+   *   A true if the method has a using [[continuations.Suspend]] parameter and has a suspended
+   *   continuation in its method body, false otherwise
    */
-  def unapply(defdef: DefDef)(using Context): Option[DefDef] =
-    if (HasSuspendParameter.unapply(defdef).isDefined && subtreeCallsSuspend(defdef.rhs))
-      Option(defdef)
-    else
-      None
+  def apply(defdef: DefDef)(using Context): Boolean =
+    HasSuspendParameter(defdef) && subtreeCallsSuspend(defdef.rhs)

--- a/continuationsPlugin/src/main/scala/continuations/CallsSuspendContinuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/CallsSuspendContinuation.scala
@@ -25,7 +25,7 @@ private[continuations] object CallsSuspendContinuation extends TreesChecks:
    *   [[scala.Some]] if the tree contains a subtree call to
    *   [[continuations.Suspend#suspendContinuation]], [[scala.None]] otherwise
    */
-  def unapply(tree: ValOrDefDef)(using Context): Option[Tree] =
+  def apply(tree: ValOrDefDef)(using Context): Boolean =
     val args =
       tree
         .rhs
@@ -51,4 +51,4 @@ private[continuations] object CallsSuspendContinuation extends TreesChecks:
             None
         }
 
-    Option.when(args.nonEmpty)(tree)
+    args.nonEmpty

--- a/continuationsPlugin/src/main/scala/continuations/CallsSuspendParameter.scala
+++ b/continuationsPlugin/src/main/scala/continuations/CallsSuspendParameter.scala
@@ -2,7 +2,7 @@ package continuations
 
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Symbols.requiredClass
+import dotty.tools.dotc.core.Symbols.{requiredClass, Symbol}
 import dotty.tools.dotc.core.Flags
 
 /**
@@ -19,14 +19,15 @@ private[continuations] object CallsSuspendParameter:
    * @param c
    *   A dotty compiler context
    * @return
-   *   a [[scala.Some]] if the tree has a given [[continuations.Suspend]] parameter,
-   *   [[scala.None]] otherwise
+   *   true if the tree has a given [[continuations.Suspend]] parameter, false otherwise
    */
-  def unapply(tree: tpd.Tree)(using c: Context): Option[tpd.Tree] =
+  def apply(tree: tpd.Tree)(using c: Context): Boolean =
+    def isGivenSuspend(s: Symbol): Boolean =
+      s.is(Flags.Given) && s
+        .info
+        .classSymbol
+        .info
+        .hasClassSymbol(requiredClass(suspendFullName))
     tree match
-      case tpd.Apply(_, args) if args.map(_.symbol).exists { s =>
-            s.is(Flags.Given) &&
-            s.info.classSymbol.info.hasClassSymbol(requiredClass(suspendFullName))
-          } =>
-        Option(tree)
-      case _ => None
+      case tpd.Apply(_, args) => args.exists(a => isGivenSuspend(a.symbol))
+      case _ => false

--- a/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ContinuationsPlugin.scala
@@ -71,7 +71,7 @@ class ContinuationsCallsPhase extends PluginPhase:
     updatedMethods.toList.find(s => s.name == tree.symbol.name && s.coord == tree.symbol.coord)
 
   private def treeIsSuspendAndNotInApplyToChange(tree: Apply)(using Context): Boolean =
-    tree.filterSubTrees(CallsSuspendParameter.unapply(_).nonEmpty).nonEmpty &&
+    tree.filterSubTrees(CallsSuspendParameter.apply).nonEmpty &&
       !applyToChange.exists(_.filterSubTrees(_.sameTree(tree)).nonEmpty)
 
   private def treeExistsIsApplyAndIsNotInApplyToChange(tree: Apply, n: Name)(

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -73,9 +73,9 @@ object DefDefTransforms extends TreesChecks:
         report.logWith("state machine and new defdef:")(transformedTree)
 
     tree match
-      case HasSuspensionNotInReturnedValue(_) =>
+      case _ if HasSuspensionNotInReturnedValue(tree) =>
         transformSuspensionsSuspendingStateMachine(fetchSuspensions, false)
-      case CallsSuspendContinuation(_) =>
+      case _ if CallsSuspendContinuation(tree) =>
         fetchSuspensions match
           case suspensionPoint :: Nil if !suspensionPoint.isInstanceOf[tpd.ValDef] =>
             transformSuspendOneContinuationResume(tree, suspensionPoint)

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -27,9 +27,10 @@ object DefDefTransforms extends TreesChecks:
 
   def transformSuspendContinuation(tree: tpd.ValOrDefDef)(using Context): tpd.Tree =
     tree match {
-      case ReturnsContextFunctionWithSuspendType(_) if !tree.symbol.isAnonymousFunction =>
+      case _
+          if ReturnsContextFunctionWithSuspendType(tree) && !tree.symbol.isAnonymousFunction =>
         report.logWith(s"new tree:")(transformContinuationWithSuspend(tree))
-      case HasSuspendParameter(_) if !tree.symbol.isAnonymousFunction =>
+      case _ if HasSuspendParameter(tree) && !tree.symbol.isAnonymousFunction =>
         report.logWith(s"new tree:")(transformContinuationWithSuspend(tree))
       case _ => report.logWith(s"oldTree:")(tree)
     }
@@ -80,7 +81,7 @@ object DefDefTransforms extends TreesChecks:
             transformSuspendOneContinuationResume(tree, suspensionPoint)
           case suspensionPoints =>
             transformSuspensionsSuspendingStateMachine(suspensionPoints, true)
-      case BodyHasSuspensionPoint(_) =>
+      case vd: tpd.DefDef if BodyHasSuspensionPoint(vd) =>
         // any suspension that still needs a transformation
         tree match
           case t: tpd.DefDef => cpy.DefDef(t)()
@@ -275,7 +276,7 @@ object DefDefTransforms extends TreesChecks:
 
   private def getReturnTypeBodyContextFunctionOwner(tree: tpd.ValOrDefDef)(
       using Context): (Type, tpd.Tree, Option[Symbol]) =
-    if (ReturnsContextFunctionWithSuspendType.unapply(tree).nonEmpty)
+    if (ReturnsContextFunctionWithSuspendType(tree))
       val returnType = removeSuspend(tree.tpt.tpe)
 
       val (rhs, contextFunctionOwner) = tree.rhs match

--- a/continuationsPlugin/src/main/scala/continuations/HasSuspensionNotInReturnedValue.scala
+++ b/continuationsPlugin/src/main/scala/continuations/HasSuspensionNotInReturnedValue.scala
@@ -20,7 +20,7 @@ private[continuations] object HasSuspensionNotInReturnedValue extends TreesCheck
    */
   def unapply(tree: ValOrDefDef)(using Context): Option[Tree] =
     val rhs =
-      if (ReturnsContextFunctionWithSuspendType.unapply(tree).nonEmpty)
+      if (ReturnsContextFunctionWithSuspendType(tree))
         tree.rhs match
           case Block(List(d @ DefDef(_, _, _, _)), _) if d.symbol.isAnonymousFunction => d.rhs
           case rhs => rhs

--- a/continuationsPlugin/src/main/scala/continuations/HasSuspensionNotInReturnedValue.scala
+++ b/continuationsPlugin/src/main/scala/continuations/HasSuspensionNotInReturnedValue.scala
@@ -18,7 +18,7 @@ private[continuations] object HasSuspensionNotInReturnedValue extends TreesCheck
    *   and [[continuations.Continuation.resume]] but not in the last row, [[scala.None]]
    *   otherwise
    */
-  def unapply(tree: ValOrDefDef)(using Context): Option[Tree] =
+  def apply(tree: ValOrDefDef)(using Context): Boolean =
     val rhs =
       if (ReturnsContextFunctionWithSuspendType(tree))
         tree.rhs match
@@ -50,7 +50,4 @@ private[continuations] object HasSuspensionNotInReturnedValue extends TreesCheck
           treeCallsSuspend(tree)
       }
 
-    if (CallsSuspendContinuation.unapply(tree).nonEmpty && !returnsSuspend)
-      Option(tree)
-    else
-      Option.empty
+    CallsSuspendContinuation(tree) && !returnsSuspend

--- a/continuationsPlugin/src/main/scala/continuations/ReturnsContextFunctionWithSuspendType.scala
+++ b/continuationsPlugin/src/main/scala/continuations/ReturnsContextFunctionWithSuspendType.scala
@@ -15,11 +15,8 @@ private[continuations] object ReturnsContextFunctionWithSuspendType:
    * @param c
    *   A dotty compiler context
    * @return
-   *   [[scala.Some]] if the tree returns a context function, [[scala.None]] otherwise.
+   *   true if the tree returns a context function, false otherwise.
    */
-  def unapply(tree: tpd.ValOrDefDef)(using c: Context): Option[tpd.Tree] =
-    Option(tree).filter { t =>
-      val tpe = t.tpt.tpe
-      IsSuspendContextFunction.unapply(tpe).isDefined ||
-      IsSuspendContextFunction.unapply(tpe.underlyingIfProxy).isDefined
-    }
+  def apply(tree: tpd.ValOrDefDef)(using c: Context): Boolean =
+    val tpe = tree.tpt.tpe
+    IsSuspendContextFunction(tpe) || IsSuspendContextFunction(tpe.underlyingIfProxy)

--- a/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
@@ -10,7 +10,7 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
        |def mySuspend()(using Suspend): Int = 1
        |should be None""".stripMargin) {
     case (given Context, defdef) =>
-      assertEquals(BodyHasSuspensionPoint.unapply(defdef), None)
+      assertEquals(BodyHasSuspensionPoint(defdef), false)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
@@ -22,7 +22,7 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
        |should be some(mySuspend)""".stripMargin) {
     case (given Context, defdef) =>
       val d = defdef
-      assertEquals(BodyHasSuspensionPoint.unapply(d), Some(d))
+      assertEquals(BodyHasSuspensionPoint(d), true)
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
@@ -31,5 +31,5 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
        |should be None""".stripMargin) {
     case (ctx, defdef) =>
       given Context = ctx
-      assertEquals(BodyHasSuspensionPoint.unapply(defdef), None)
+      assertEquals(BodyHasSuspensionPoint(defdef), false)
   }

--- a/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
 class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
 
   continuationsContextAndZeroArityNonSuspendNonSuspendingDefDef.test(
-    """|BodyHasNoSuspensionPoint#unapply(defDefTree):
+    """|BodyHasNoSuspensionPoint#apply(defDefTree):
        |def mySuspend()(using Suspend): Int = 1
        |should be None""".stripMargin) {
     case (given Context, defdef) =>
@@ -14,7 +14,7 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
   }
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
-    """|BodyHasNoSuspensionPoint#unapply(defDefTree):
+    """|BodyHasNoSuspensionPoint#apply(defDefTree):
        |def mySuspend()(using Suspend): Int =
        |  summon[Suspend].suspendContinuation[Int] {continuation =>
        |    continuation.resume(Right(1))
@@ -26,7 +26,7 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
-    """|BodyHasNoSuspensionPoint#unapply(defDefTree):
+    """|BodyHasNoSuspensionPoint#apply(defDefTree):
        |def mySuspend()(using Suspend): Int = 1
        |should be None""".stripMargin) {
     case (ctx, defdef) =>

--- a/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
@@ -12,7 +12,7 @@ import munit.FunSuite
 class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
-    "CallsContinuationResumeWith#unapply(defDefTree): def mySuspend()(using Suspend): Int = " +
+    "CallsContinuationResumeWith#apply(defDefTree): def mySuspend()(using Suspend): Int = " +
       "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) } should be Some(mySuspend)") {
     case (given Context, defdef) =>
       // because this is a subtree projection, we cannot use tree
@@ -25,20 +25,20 @@ class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
-    "CallsContinuationResumeWith#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be None") {
+    "CallsContinuationResumeWith#apply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be None") {
     case (given Context, defdef) =>
       assertEquals(CallsSuspendContinuation(defdef), false)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingValDef.test(
-    "CallsContinuationResumeWith#unapply(valDefTree): val mySuspend: Suspend ?=> Int = " +
+    "CallsContinuationResumeWith#apply(valDefTree): val mySuspend: Suspend ?=> Int = " +
       "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) } should be Some(mySuspend)") {
     case (given Context, valdef) =>
       assertEquals(CallsSuspendContinuation(valdef), true)
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingValDef.test(
-    "CallsContinuationResumeWith#unapply(valDefTree): val mySuspend: Suspend ?=> Int = 10 should be None") {
+    "CallsContinuationResumeWith#apply(valDefTree): val mySuspend: Suspend ?=> Int = 10 should be None") {
     case (given Context, valdef) =>
       assertEquals(CallsSuspendContinuation(valdef), false)
   }

--- a/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
@@ -21,24 +21,24 @@ class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
       // reference equality. We can use NoDiff on the printed returned
       // tree, however, since we know we do not modify the inner tree in
       // the extractor.
-      assertNoDiff(CallsSuspendContinuation.unapply(defdef).get.toString, defdef.toString)
+      assertEquals(CallsSuspendContinuation(defdef), true)
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
     "CallsContinuationResumeWith#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be None") {
     case (given Context, defdef) =>
-      assertEquals(CallsSuspendContinuation.unapply(defdef), None)
+      assertEquals(CallsSuspendContinuation(defdef), false)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingValDef.test(
     "CallsContinuationResumeWith#unapply(valDefTree): val mySuspend: Suspend ?=> Int = " +
       "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) } should be Some(mySuspend)") {
     case (given Context, valdef) =>
-      assertNoDiff(CallsSuspendContinuation.unapply(valdef).get.toString, valdef.toString)
+      assertEquals(CallsSuspendContinuation(valdef), true)
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingValDef.test(
     "CallsContinuationResumeWith#unapply(valDefTree): val mySuspend: Suspend ?=> Int = 10 should be None") {
     case (given Context, valdef) =>
-      assertEquals(CallsSuspendContinuation.unapply(valdef), None)
+      assertEquals(CallsSuspendContinuation(valdef), false)
   }

--- a/continuationsPlugin/src/test/scala/continuations/CallsSuspendParameterSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CallsSuspendParameterSuite.scala
@@ -12,7 +12,9 @@ class CallsSuspendParameterSuite extends FunSuite, CompilerFixtures {
       val call = tree match
         case Block(_, call) => call
 
-      assertNoDiff(CallsSuspendParameter.unapply(call).get.show, call.show)
+      val prev = call.show
+      val _ = CallsSuspendParameter(call)
+      assertNoDiff(call.show, prev)
   }
 
   continutationsContextAndMethodCallWithoutSuspend.test(
@@ -21,7 +23,7 @@ class CallsSuspendParameterSuite extends FunSuite, CompilerFixtures {
       val call = tree match
         case Block(_, call) => call
 
-      assertEquals(CallsSuspendParameter.unapply(call), None)
+      assertEquals(CallsSuspendParameter(call), false)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(

--- a/continuationsPlugin/src/test/scala/continuations/CallsSuspendParameterSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CallsSuspendParameterSuite.scala
@@ -29,6 +29,6 @@ class CallsSuspendParameterSuite extends FunSuite, CompilerFixtures {
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
     "should return None when the tree is not a method call") {
     case (given Context, tree) =>
-      assertEquals(HasSuspensionNotInReturnedValue.unapply(tree), None)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), false)
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/HasSuspendParameterSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/HasSuspendParameterSuite.scala
@@ -8,9 +8,7 @@ class HasSuspendParameterSuite extends FunSuite, CompilerFixtures {
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
     "#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
     case (given Context, defdef) =>
-      val before = defdef.show
-      val _ = HasSuspendParameter(defdef)
-      assertNoDiff(defdef.show, before)
+      assertEquals(HasSuspendParameter(defdef), true)
   }
 
   continuationsContextAndZeroArityNonSuspendNonSuspendingDefDef.test(

--- a/continuationsPlugin/src/test/scala/continuations/HasSuspendParameterSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/HasSuspendParameterSuite.scala
@@ -6,19 +6,19 @@ import munit.FunSuite
 class HasSuspendParameterSuite extends FunSuite, CompilerFixtures {
 
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
-    "#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
+    "#apply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
     case (given Context, defdef) =>
       assertEquals(HasSuspendParameter(defdef), true)
   }
 
   continuationsContextAndZeroArityNonSuspendNonSuspendingDefDef.test(
-    "#unapply(defDefTree): def mySuspend(s: Suspend): Int = 1 should be None") {
+    "#apply(defDefTree): def mySuspend(s: Suspend): Int = 1 should be None") {
     case (given Context, defdef) =>
       assertEquals(HasSuspendParameter(defdef), false)
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingValDef.test(
-    "#unapply(valDefTree): def mySuspend: Suspend ?=> Int = 1 should be None") {
+    "#apply(valDefTree): def mySuspend: Suspend ?=> Int = 1 should be None") {
     case (given Context, valdef) =>
       assertEquals(HasSuspendParameter(valdef), false)
   }

--- a/continuationsPlugin/src/test/scala/continuations/HasSuspendParameterSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/HasSuspendParameterSuite.scala
@@ -8,18 +8,20 @@ class HasSuspendParameterSuite extends FunSuite, CompilerFixtures {
   continuationsContextAndZeroAritySuspendNonSuspendingDefDef.test(
     "#unapply(defDefTree): def mySuspend()(using Suspend): Int = 1 should be Some(tree)") {
     case (given Context, defdef) =>
-      assertNoDiff(HasSuspendParameter.unapply(defdef).get.show, defdef.show)
+      val before = defdef.show
+      val _ = HasSuspendParameter(defdef)
+      assertNoDiff(defdef.show, before)
   }
 
   continuationsContextAndZeroArityNonSuspendNonSuspendingDefDef.test(
     "#unapply(defDefTree): def mySuspend(s: Suspend): Int = 1 should be None") {
     case (given Context, defdef) =>
-      assertEquals(HasSuspendParameter.unapply(defdef), None)
+      assertEquals(HasSuspendParameter(defdef), false)
   }
 
   continuationsContextAndZeroAritySuspendNonSuspendingValDef.test(
     "#unapply(valDefTree): def mySuspend: Suspend ?=> Int = 1 should be None") {
     case (given Context, valdef) =>
-      assertEquals(HasSuspendParameter.unapply(valdef), None)
+      assertEquals(HasSuspendParameter(valdef), false)
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/HasSuspensionNotInReturnedValueSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/HasSuspensionNotInReturnedValueSuite.scala
@@ -9,42 +9,42 @@ class HasSuspensionNotInReturnedValueSuite extends FunSuite, CompilerFixtures {
   continuationsContextAndZeroAritySuspendSuspendingNotInLastRowDefDef.test(
     "should return Some(tree) when the tree has a continuation but not in the last row") {
     case (given Context, tree) =>
-      assertNoDiff(HasSuspensionNotInReturnedValue.unapply(tree).get.show, tree.show)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), true)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
     "should return None when the tree has a continuation in the last row") {
     case (given Context, tree) =>
-      assertEquals(HasSuspensionNotInReturnedValue.unapply(tree), None)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), false)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingNotInLastRowIfDefDef.test(
     "should return Some(tree) when the tree has a continuation but not in the last row for structures like `if`") {
     case (given Context, tree) =>
-      assertNoDiff(HasSuspensionNotInReturnedValue.unapply(tree).get.show, tree.show)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), true)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingInLastRowIfDefDef.test(
     "should return None when the tree has a continuation in the last row for structures like `if`") {
     case (given Context, tree) =>
-      assertEquals(HasSuspensionNotInReturnedValue.unapply(tree), None)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), false)
   }
 
   continuationsContextAndZeroArityContextFunctionWithSuspensionNotInLastRowDefDef.test(
     "should return Some(tree) when the tree has a continuation but not in the last row for context functions") {
     case (given Context, tree) =>
-      assertNoDiff(HasSuspensionNotInReturnedValue.unapply(tree).get.show, tree.show)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), true)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingNotInLastRowValDef.test(
     "should return Some(tree) when the tree has a continuation but not in the last row for a val") {
     case (given Context, tree) =>
-      assertNoDiff(HasSuspensionNotInReturnedValue.unapply(tree).get.show, tree.show)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), true)
   }
 
   continuationsContextAndZeroAritySuspendSuspendingValDef.test(
     "should return None when the tree has a continuation in the last row for a val") {
     case (given Context, tree) =>
-      assertEquals(HasSuspensionNotInReturnedValue.unapply(tree), None)
+      assertEquals(HasSuspensionNotInReturnedValue(tree), false)
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/IsSuspendContextFunctionSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/IsSuspendContextFunctionSuite.scala
@@ -13,7 +13,7 @@ class IsSuspendContextFunctionSuite extends FunSuite, CompilerFixtures {
     case (c, suspendContextFunction) =>
       given Context = c
       val t = suspendContextFunction
-      assertEquals(IsSuspendContextFunction.unapply(t), Some(t))
+      assertEquals(IsSuspendContextFunction(t), true)
   }
 
   continuationsContextAndSuspendContextFunctionReturningSuspend.test(
@@ -21,23 +21,21 @@ class IsSuspendContextFunctionSuite extends FunSuite, CompilerFixtures {
     case (c, suspendContextFunctionReturningSuspend) =>
       given Context = c
       val t = suspendContextFunctionReturningSuspend
-      assertEquals(IsSuspendContextFunction.unapply(t), Some(t))
+      assertEquals(IsSuspendContextFunction(t), true)
   }
 
   continuationsContextAndNonSuspendContextFunctionReturingSuspend.test(
     "It should not detect context functions with Suspend as a return if Suspend is not a parameter") {
     case (c, nonSuspendContextFunctionReturingSuspend) =>
       given Context = c
-      assertEquals(
-        IsSuspendContextFunction.unapply(nonSuspendContextFunctionReturingSuspend),
-        None)
+      assertEquals(IsSuspendContextFunction(nonSuspendContextFunctionReturingSuspend), false)
   }
 
   continuationsContextAndNonSuspendContextFunction.test(
     "It should not detect context functions without Suspend as a parameter") {
     case (c, nonSuspendContextFunction) =>
       given Context = c
-      assertEquals(IsSuspendContextFunction.unapply(nonSuspendContextFunction), None)
+      assertEquals(IsSuspendContextFunction(nonSuspendContextFunction), false)
   }
 
   compilerContextWithContinuationsPlugin.test(
@@ -51,6 +49,6 @@ class IsSuspendContextFunctionSuite extends FunSuite, CompilerFixtures {
       val type4 = defn.FunctionOf(List(defn.StringType), type3, isContextual = true)
       val type5 = defn.FunctionOf(List(defn.IntType), type4)
 
-      assertEquals(IsSuspendContextFunction.unapply(type5), Some(type5))
+      assertEquals(IsSuspendContextFunction(type5), true)
   }
 }

--- a/continuationsPlugin/src/test/scala/continuations/ReturnsContextFunctionWithSuspendTypeSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ReturnsContextFunctionWithSuspendTypeSuite.scala
@@ -11,7 +11,7 @@ class ReturnsContextFunctionWithSuspendTypeSuite extends FunSuite, CompilerFixtu
     case (c, zeroArityContextFunctionDefDef) =>
       given Context = c
       val t = zeroArityContextFunctionDefDef
-      assertEquals(ReturnsContextFunctionWithSuspendType.unapply(t), Some(t))
+      assertEquals(ReturnsContextFunctionWithSuspendType(t), true)
   }
 
   continuationsContextAndSuspendingContextFunctionValDef.test(
@@ -19,7 +19,7 @@ class ReturnsContextFunctionWithSuspendTypeSuite extends FunSuite, CompilerFixtu
     case (c, suspendingContextFunctionValDef) =>
       given Context = c
       val t = suspendingContextFunctionValDef
-      assertEquals(ReturnsContextFunctionWithSuspendType.unapply(t), Some(t))
+      assertEquals(ReturnsContextFunctionWithSuspendType(t), true)
   }
 
   continuationsContextAndNonSuspendingContextFunctionValDef.test(
@@ -27,5 +27,5 @@ class ReturnsContextFunctionWithSuspendTypeSuite extends FunSuite, CompilerFixtu
     case (c, nonSuspendingContextFunctionValDef) =>
       given Context = c
       val t = nonSuspendingContextFunctionValDef
-      assertEquals(ReturnsContextFunctionWithSuspendType.unapply(t), None)
+      assertEquals(ReturnsContextFunctionWithSuspendType(t), false)
   }


### PR DESCRIPTION
If the tree you may return in the `Some` is the same as the input, that is  not a matcher, that is a predicate. However, is there anything else going on in this processes? 

Otherwise, does the 