### PR TITLE
Refactor - Split last method, move out the "report"

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -59,15 +59,27 @@ object DefDefTransforms extends TreesChecks:
         .toList
         .flatten
 
+    def transformSuspensionsSuspendingStateMachine(
+        suspensionPoints: List[tpd.Tree],
+        suspensionInReturnedValue: Boolean)(using ctx: Context) =
+      if suspensionPoints.isEmpty then tree
+      else
+        val transformedTree =
+          transformSuspensionsSuspendingStateMachineAux(
+            tree,
+            suspensionPoints,
+            suspensionInReturnedValue)
+        report.logWith("state machine and new defdef:")(transformedTree)
+
     tree match
       case HasSuspensionNotInReturnedValue(_) =>
-        transformSuspensionsSuspendingStateMachine(tree, fetchSuspensions, false)
+        transformSuspensionsSuspendingStateMachine(fetchSuspensions, false)
       case CallsSuspendContinuation(_) =>
         fetchSuspensions match
           case suspensionPoint :: Nil if !suspensionPoint.isInstanceOf[tpd.ValDef] =>
             transformSuspendOneContinuationResume(tree, suspensionPoint)
           case suspensionPoints =>
-            transformSuspensionsSuspendingStateMachine(tree, suspensionPoints, true)
+            transformSuspensionsSuspendingStateMachine(suspensionPoints, true)
       case BodyHasSuspensionPoint(_) =>
         // any suspension that still needs a transformation
         tree match
@@ -520,746 +532,730 @@ object DefDefTransforms extends TreesChecks:
     )
   }
 
-  private def transformSuspensionsSuspendingStateMachine(
+  private def transformSuspensionsSuspendingStateMachineAux(
       tree: tpd.ValOrDefDef,
       suspensionPoints: List[tpd.Tree],
-      suspensionInReturnedValue: Boolean)(using ctx: Context) =
-    suspensionPoints match
-      case Nil => tree
-      case _ =>
-        val suspensionPointsVal: List[tpd.Tree] =
-          suspensionPoints.collect { case vd: tpd.ValDef => vd }
-        val suspensionPointsSize = suspensionPoints.size
+      suspensionInReturnedValue: Boolean)(using ctx: Context): tpd.Thicket =
+    val suspensionPointsVal: List[tpd.Tree] =
+      suspensionPoints.collect { case vd: tpd.ValDef => vd }
+    val suspensionPointsSize = suspensionPoints.size
 
-        val continuationClassRef = requiredClassRef(continuationFullName)
-        val continuationModule = requiredModule(continuationFullName)
-        val safeContinuationClass = requiredClass("continuations.SafeContinuation")
-        val interceptedMethod =
-          requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
-        val continuationImplClass = requiredClass("continuations.jvm.internal.ContinuationImpl")
+    val continuationClassRef = requiredClassRef(continuationFullName)
+    val continuationModule = requiredModule(continuationFullName)
+    val safeContinuationClass = requiredClass("continuations.SafeContinuation")
+    val interceptedMethod =
+      requiredPackage("continuations.intrinsics").requiredMethod("intercepted")
+    val continuationImplClass = requiredClass("continuations.jvm.internal.ContinuationImpl")
 
-        val parent = tree.symbol
-        val treeOwner = parent.owner
-        val defName = parent.name
+    val parent = tree.symbol
+    val treeOwner = parent.owner
+    val defName = parent.name
 
-        val (returnType, rhs, contextFunctionOwner) =
-          getReturnTypeBodyContextFunctionOwner(tree)
+    val (returnType, rhs, contextFunctionOwner) =
+      getReturnTypeBodyContextFunctionOwner(tree)
 
-        val suspendedState =
-          ref(continuationModule).select(termName("State")).select(termName("Suspended"))
-        val newReturnType =
-          tpd.TypeTree(
-            Types.OrType(Types.OrNull(returnType), suspendedState.symbol.namedType, false)
-          )
+    val suspendedState =
+      ref(continuationModule).select(termName("State")).select(termName("Suspended"))
+    val newReturnType =
+      tpd.TypeTree(
+        Types.OrType(Types.OrNull(returnType), suspendedState.symbol.namedType, false)
+      )
 
-        val integerOR =
-          defn.IntClass.requiredMethod(nme.OR, List(defn.IntType))
-        val integerAND =
-          defn.IntClass.requiredMethod(nme.AND, List(defn.IntType))
-        val integerNE =
-          defn.IntClass.requiredMethod(nme.NE, List(defn.IntType))
-        val integerMin =
-          ref(requiredModuleRef("scala.Int").select(Names.termName("MinValue")).symbol)
+    val integerOR =
+      defn.IntClass.requiredMethod(nme.OR, List(defn.IntType))
+    val integerAND =
+      defn.IntClass.requiredMethod(nme.AND, List(defn.IntType))
+    val integerNE =
+      defn.IntClass.requiredMethod(nme.NE, List(defn.IntType))
+    val integerMin =
+      ref(requiredModuleRef("scala.Int").select(Names.termName("MinValue")).symbol)
 
-        val intType = defn.IntType
-        val anyType = defn.AnyType
-        val anyOrNullType = Types.OrNull(anyType)
-        val anyNullSuspendedType =
-          Types.OrType(Types.OrNull(defn.AnyType), suspendedState.symbol.namedType, false)
+    val intType = defn.IntType
+    val anyType = defn.AnyType
+    val anyOrNullType = Types.OrNull(anyType)
+    val anyNullSuspendedType =
+      Types.OrType(Types.OrNull(defn.AnyType), suspendedState.symbol.namedType, false)
 
-        val stateMachineContinuationClassName =
-          s"${treeOwner.name.show}$$$defName$$1"
+    val stateMachineContinuationClassName =
+      s"${treeOwner.name.show}$$$defName$$1"
 
-        val continuationsStateMachineSymbol = newCompleteClassSymbol(
-          treeOwner,
-          typeName(stateMachineContinuationClassName),
-          SyntheticArtifact,
-          List(continuationImplClass.typeRef),
-          Scopes.newScope
-        ).entered.asClass
+    val continuationsStateMachineSymbol = newCompleteClassSymbol(
+      treeOwner,
+      typeName(stateMachineContinuationClassName),
+      SyntheticArtifact,
+      List(continuationImplClass.typeRef),
+      Scopes.newScope
+    ).entered.asClass
 
-        val completionParamName = termName("$completion")
-        val resultVarName = termName("$result")
-        val labelVarParam = termName("$label")
+    val completionParamName = termName("$completion")
+    val resultVarName = termName("$result")
+    val labelVarParam = termName("$label")
 
-        val continuationsStateMachineConstructor = {
-          val symbol = newConstructor(
-            continuationsStateMachineSymbol,
-            Flags.Synthetic,
-            List(completionParamName),
-            List(continuationClassRef.appliedTo(anyOrNullType))
-          ).entered.asTerm
+    val continuationsStateMachineConstructor = {
+      val symbol = newConstructor(
+        continuationsStateMachineSymbol,
+        Flags.Synthetic,
+        List(completionParamName),
+        List(continuationClassRef.appliedTo(anyOrNullType))
+      ).entered.asTerm
 
-          tpd.DefDef(symbol)
+      tpd.DefDef(symbol)
+    }
+
+    val eitherThrowableAnyNullSuspendedType =
+      requiredClassRef("scala.util.Either").appliedTo(
+        defn.ThrowableType,
+        anyNullSuspendedType
+      )
+    val continuationStateMachineResult = tpd.ValDef(
+      newSymbol(
+        continuationsStateMachineSymbol,
+        resultVarName,
+        Flags.Synthetic | Flags.Mutable,
+        eitherThrowableAnyNullSuspendedType).entered,
+      Underscore(eitherThrowableAnyNullSuspendedType)
+    )
+
+    val continuationStateMachineLabel = tpd.ValDef(
+      newSymbol(
+        continuationsStateMachineSymbol,
+        labelVarParam,
+        Flags.Synthetic | Flags.Mutable,
+        intType).entered,
+      Underscore(intType)
+    )
+
+    val continuationsStateMachineThis: tpd.This =
+      tpd.This(continuationsStateMachineSymbol)
+
+    val continuationsStateMachineLabelSelect =
+      continuationsStateMachineThis.select(labelVarParam)
+
+    val completion = generateCompletion(parent, returnType)
+
+    val transformedMethodParams = params(tree, completion)
+
+    val transformedMethodSymbol =
+      createTransformedMethodSymbol(parent, transformedMethodParams, newReturnType.tpe)
+
+    deleteOldSymbol(parent)
+
+    val transformedMethod: tpd.DefDef =
+      tpd.DefDef(sym = transformedMethodSymbol)
+
+    val transformedMethodCompletionParam = ref(
+      transformedMethod.termParamss.flatten.find(_.symbol.denot.matches(completion)).get.symbol)
+
+    val transformedMethodParamsWithoutCompletion =
+      transformedMethod.termParamss.flatten.filterNot(_.symbol.denot.matches(completion))
+
+    val numTransformedMethodOriginalParams =
+      transformedMethod.termParamss.map(_.length).sum - 1
+
+    val $completion = continuationsStateMachineConstructor
+      .termParamss
+      .flatten
+      .find(_.name.matchesTargetName(completionParamName))
+      .get
+      .symbol
+
+    val continuationStateMachineResultSetter =
+      newSymbol(
+        continuationsStateMachineSymbol,
+        continuationStateMachineResult.symbol.asTerm.name.setterName,
+        Method | Flags.Accessor,
+        info = MethodType(
+          continuationStateMachineResult.symbol.asTerm.info.widenExpr :: Nil,
+          defn.UnitType)
+      ).entered
+
+    val continuationStateMachineLabelSetter =
+      newSymbol(
+        continuationsStateMachineSymbol,
+        continuationStateMachineLabel.symbol.asTerm.name.setterName,
+        Method | Flags.Accessor,
+        info = MethodType(
+          continuationStateMachineLabel.symbol.asTerm.info.widenExpr :: Nil,
+          defn.UnitType)
+      ).entered
+
+    val (rowsBeforeSuspensionPoint, rowsAfterLastSuspensionPoint)
+        : (Map[tpd.Tree, List[tpd.Tree]], List[tpd.Tree]) =
+      rhs
+        .toList
+        .flatMap {
+          case Trees.Block(trees, tree) => trees :+ tree
+          case tree => List(tree)
         }
-
-        val eitherThrowableAnyNullSuspendedType =
-          requiredClassRef("scala.util.Either").appliedTo(
-            defn.ThrowableType,
-            anyNullSuspendedType
-          )
-        val continuationStateMachineResult = tpd.ValDef(
-          newSymbol(
-            continuationsStateMachineSymbol,
-            resultVarName,
-            Flags.Synthetic | Flags.Mutable,
-            eitherThrowableAnyNullSuspendedType).entered,
-          Underscore(eitherThrowableAnyNullSuspendedType)
-        )
-
-        val continuationStateMachineLabel = tpd.ValDef(
-          newSymbol(
-            continuationsStateMachineSymbol,
-            labelVarParam,
-            Flags.Synthetic | Flags.Mutable,
-            intType).entered,
-          Underscore(intType)
-        )
-
-        val continuationsStateMachineThis: tpd.This =
-          tpd.This(continuationsStateMachineSymbol)
-
-        val continuationsStateMachineLabelSelect =
-          continuationsStateMachineThis.select(labelVarParam)
-
-        val completion = generateCompletion(parent, returnType)
-
-        val transformedMethodParams = params(tree, completion)
-
-        val transformedMethodSymbol =
-          createTransformedMethodSymbol(parent, transformedMethodParams, newReturnType.tpe)
-
-        deleteOldSymbol(parent)
-
-        val transformedMethod: tpd.DefDef =
-          tpd.DefDef(sym = transformedMethodSymbol)
-
-        val transformedMethodCompletionParam = ref(
-          transformedMethod
-            .termParamss
-            .flatten
-            .find(_.symbol.denot.matches(completion))
-            .get
-            .symbol)
-
-        val transformedMethodParamsWithoutCompletion =
-          transformedMethod.termParamss.flatten.filterNot(_.symbol.denot.matches(completion))
-
-        val numTransformedMethodOriginalParams =
-          transformedMethod.termParamss.map(_.length).sum - 1
-
-        val $completion = continuationsStateMachineConstructor
-          .termParamss
-          .flatten
-          .find(_.name.matchesTargetName(completionParamName))
-          .get
-          .symbol
-
-        val continuationStateMachineResultSetter =
-          newSymbol(
-            continuationsStateMachineSymbol,
-            continuationStateMachineResult.symbol.asTerm.name.setterName,
-            Method | Flags.Accessor,
-            info = MethodType(
-              continuationStateMachineResult.symbol.asTerm.info.widenExpr :: Nil,
-              defn.UnitType)
-          ).entered
-
-        val continuationStateMachineLabelSetter =
-          newSymbol(
-            continuationsStateMachineSymbol,
-            continuationStateMachineLabel.symbol.asTerm.name.setterName,
-            Method | Flags.Accessor,
-            info = MethodType(
-              continuationStateMachineLabel.symbol.asTerm.info.widenExpr :: Nil,
-              defn.UnitType)
-          ).entered
-
-        val (rowsBeforeSuspensionPoint, rowsAfterLastSuspensionPoint)
-            : (Map[tpd.Tree, List[tpd.Tree]], List[tpd.Tree]) =
-          rhs
-            .toList
-            .flatMap {
-              case Trees.Block(trees, tree) => trees :+ tree
-              case tree => List(tree)
-            }
-            .foldLeft((0, Map.empty[tpd.Tree, List[tpd.Tree]], List.empty[tpd.Tree])) {
-              case ((suspensionPointsCounter, rowsBefore, rowsAfterLast), row) =>
-                if (treeCallsSuspend(row) || valDefTreeCallsSuspend(row))
-                  (
-                    suspensionPointsCounter + 1,
-                    rowsBefore.updatedWith(suspensionPoints(suspensionPointsCounter)) {
-                      case None => Option(List.empty)
-                      case rows => rows
-                    },
-                    rowsAfterLast)
-                else if (suspensionPointsCounter < suspensionPointsSize)
-                  (
-                    suspensionPointsCounter,
-                    rowsBefore.updatedWith(suspensionPoints(suspensionPointsCounter)) {
-                      case Some(ll) => Option(ll :+ row)
-                      case None => Option(row :: Nil)
-                    },
-                    rowsAfterLast)
-                else (suspensionPointsCounter, rowsBefore, row :: rowsAfterLast)
-            }
-            .drop(1)
-
-        def toTreeBeforeSuspend(
-            suspend: tpd.Tree,
-            rows: List[tpd.Tree],
-            i: Int): List[tpd.Tree] = {
-          val rowsAfter =
-            rowsBeforeSuspensionPoint.drop(i + 1).values.toList.flatten ++
-              rowsBeforeSuspensionPoint.drop(i + 1).keySet ++
-              rowsAfterLastSuspensionPoint
-
-          (rows :+ suspend).collect { case vd: tpd.ValDef => vd }.flatMap { vd =>
-            rowsAfter.flatMap(_.shallowFold(List.empty[tpd.Tree]) {
-              case (usedTrees, Trees.Inlined(call, _, _)) =>
-                call.filterSubTrees(_.symbol.coord == vd.symbol.coord) ++ usedTrees
-              case (usedTrees, tree) =>
-                if (tree.symbol.coord == vd.symbol.coord) tree :: usedTrees
-                else usedTrees
-            })
-          }
+        .foldLeft((0, Map.empty[tpd.Tree, List[tpd.Tree]], List.empty[tpd.Tree])) {
+          case ((suspensionPointsCounter, rowsBefore, rowsAfterLast), row) =>
+            if (treeCallsSuspend(row) || valDefTreeCallsSuspend(row))
+              (
+                suspensionPointsCounter + 1,
+                rowsBefore.updatedWith(suspensionPoints(suspensionPointsCounter)) {
+                  case None => Option(List.empty)
+                  case rows => rows
+                },
+                rowsAfterLast)
+            else if (suspensionPointsCounter < suspensionPointsSize)
+              (
+                suspensionPointsCounter,
+                rowsBefore.updatedWith(suspensionPoints(suspensionPointsCounter)) {
+                  case Some(ll) => Option(ll :+ row)
+                  case None => Option(row :: Nil)
+                },
+                rowsAfterLast)
+            else (suspensionPointsCounter, rowsBefore, row :: rowsAfterLast)
         }
+        .drop(1)
 
-        val treesBeforeSuspendUsedAfterwards: List[tpd.Tree] =
-          rowsBeforeSuspensionPoint
-            .toList
-            .zipWithIndex
-            .flatMap { case ((suspend, rows), i) => toTreeBeforeSuspend(suspend, rows, i) }
-            .distinctBy(_.symbol.coord)
+    def toTreeBeforeSuspend(suspend: tpd.Tree, rows: List[tpd.Tree], i: Int): List[tpd.Tree] = {
+      val rowsAfter =
+        rowsBeforeSuspensionPoint.drop(i + 1).values.toList.flatten ++
+          rowsBeforeSuspensionPoint.drop(i + 1).keySet ++
+          rowsAfterLastSuspensionPoint
 
-        def toGlobalVar(tree: tpd.Tree): tpd.ValDef =
+      (rows :+ suspend).collect { case vd: tpd.ValDef => vd }.flatMap { vd =>
+        rowsAfter.flatMap(_.shallowFold(List.empty[tpd.Tree]) {
+          case (usedTrees, Trees.Inlined(call, _, _)) =>
+            call.filterSubTrees(_.symbol.coord == vd.symbol.coord) ++ usedTrees
+          case (usedTrees, tree) =>
+            if (tree.symbol.coord == vd.symbol.coord) tree :: usedTrees
+            else usedTrees
+        })
+      }
+    }
+
+    val treesBeforeSuspendUsedAfterwards: List[tpd.Tree] =
+      rowsBeforeSuspensionPoint
+        .toList
+        .zipWithIndex
+        .flatMap { case ((suspend, rows), i) => toTreeBeforeSuspend(suspend, rows, i) }
+        .distinctBy(_.symbol.coord)
+
+    def toGlobalVar(tree: tpd.Tree): tpd.ValDef =
+      tpd.ValDef(
+        newSymbol(
+          transformedMethod.symbol,
+          tree.symbol.asTerm.name,
+          Local | Mutable | Synthetic,
+          tree.symbol.info,
+          coord = tree.symbol.coord).entered,
+        nullLiteral
+      )
+
+    val globalVars: List[tpd.Tree] =
+      (treesBeforeSuspendUsedAfterwards ++ suspensionPointsVal)
+        .distinctBy(_.symbol.coord)
+        .map(toGlobalVar)
+
+    val transformedMethodParamsAsVals: List[tpd.Tree] =
+      transformedMethodParamsWithoutCompletion.collect {
+        case vd: tpd.ValDef =>
           tpd.ValDef(
             newSymbol(
               transformedMethod.symbol,
-              tree.symbol.asTerm.name,
+              termName(vd.name.toString + "##1"),
               Local | Mutable | Synthetic,
-              tree.symbol.info,
-              coord = tree.symbol.coord).entered,
-            nullLiteral
+              vd.symbol.info,
+              coord = vd.symbol.coord
+            ).entered,
+            ref(vd.symbol)
           )
+      }
 
-        val globalVars: List[tpd.Tree] =
-          (treesBeforeSuspendUsedAfterwards ++ suspensionPointsVal)
-            .distinctBy(_.symbol.coord)
-            .map(toGlobalVar)
+    def contFsmI(i: Int): tpd.ValDef =
+      tpd.ValDef(
+        newSymbol(
+          continuationsStateMachineSymbol,
+          termName(s"I$$$i"),
+          Flags.Synthetic | Flags.Mutable,
+          anyType).entered,
+        Underscore(anyType))
 
-        val transformedMethodParamsAsVals: List[tpd.Tree] =
-          transformedMethodParamsWithoutCompletion.collect {
-            case vd: tpd.ValDef =>
-              tpd.ValDef(
-                newSymbol(
-                  transformedMethod.symbol,
-                  termName(vd.name.toString + "##1"),
-                  Local | Mutable | Synthetic,
-                  vd.symbol.info,
-                  coord = vd.symbol.coord
-                ).entered,
-                ref(vd.symbol)
-              )
-          }
+    val continuationStateMachineI$Ns = {
+      val numVal = transformedMethodParamsAsVals.size + globalVars.size
+      Range(0, numVal).toList.map(contFsmI)
+    }
 
-        def contFsmI(i: Int): tpd.ValDef =
-          tpd.ValDef(
-            newSymbol(
-              continuationsStateMachineSymbol,
-              termName(s"I$$$i"),
-              Flags.Synthetic | Flags.Mutable,
-              anyType).entered,
-            Underscore(anyType))
+    val continuationStateMachineClass: tpd.TypeDef =
 
-        val continuationStateMachineI$Ns = {
-          val numVal = transformedMethodParamsAsVals.size + globalVars.size
-          Range(0, numVal).toList.map(contFsmI)
-        }
+      def toContFsmSetter(vd: tpd.ValDef): tpd.DefDef = {
+        val sym = newSymbol(
+          continuationsStateMachineSymbol,
+          vd.symbol.asTerm.name.setterName,
+          Method | Flags.Accessor,
+          info = MethodType(vd.symbol.asTerm.info.widenExpr :: Nil, defn.UnitType)
+        ).entered
+        tpd.DefDef(sym, tpd.unitLiteral)
+      }
 
-        val continuationStateMachineClass: tpd.TypeDef =
-
-          def toContFsmSetter(vd: tpd.ValDef): tpd.DefDef = {
-            val sym = newSymbol(
-              continuationsStateMachineSymbol,
-              vd.symbol.asTerm.name.setterName,
-              Method | Flags.Accessor,
-              info = MethodType(vd.symbol.asTerm.info.widenExpr :: Nil, defn.UnitType)
-            ).entered
-            tpd.DefDef(sym, tpd.unitLiteral)
-          }
-
-          val invokeSuspendSymbol =
-            newSymbol(
-              continuationsStateMachineSymbol,
-              Names.termName("invokeSuspend"),
-              Flags.Override | Flags.Protected | Flags.Method,
-              MethodType(
-                List(termName("result")),
-                List(eitherThrowableAnyNullSuspendedType),
-                anyOrNullType
-              )
-            ).entered.asTerm
-
-          val invokeSuspendMethod = tpd.DefDef(
-            invokeSuspendSymbol,
-            paramss =>
-              tpd.Block(
-                List(
-                  tpd.Assign(
-                    continuationsStateMachineThis.select(resultVarName),
-                    paramss.head.head),
-                  tpd.Assign(
-                    continuationsStateMachineLabelSelect,
-                    continuationsStateMachineLabelSelect.select(integerOR).appliedTo(integerMin)
-                  )
-                ),
-                ref(transformedMethod.symbol).appliedToTermArgs(
-                  List.fill(numTransformedMethodOriginalParams)(nullLiteral) :+
-                    continuationsStateMachineThis
-                      .select(nme.asInstanceOf_)
-                      .appliedToType(continuationClassRef.appliedTo(returnType))
-                )
-              )
+      val invokeSuspendSymbol =
+        newSymbol(
+          continuationsStateMachineSymbol,
+          Names.termName("invokeSuspend"),
+          Flags.Override | Flags.Protected | Flags.Method,
+          MethodType(
+            List(termName("result")),
+            List(eitherThrowableAnyNullSuspendedType),
+            anyOrNullType
           )
+        ).entered.asTerm
 
-          ClassDefWithParents(
-            continuationsStateMachineSymbol,
-            continuationsStateMachineConstructor,
+      val invokeSuspendMethod = tpd.DefDef(
+        invokeSuspendSymbol,
+        paramss =>
+          tpd.Block(
             List(
               tpd
-                .New(ref(continuationImplClass))
-                .select(nme.CONSTRUCTOR)
-                .appliedTo(
-                  ref($completion),
-                  ref($completion).select(termName("context"))
-                )),
-            List(
-              continuationStateMachineI$Ns,
-              continuationStateMachineI$Ns.map(toContFsmSetter),
-              List(
-                continuationStateMachineResult,
-                continuationStateMachineLabel,
-                tpd.DefDef(continuationStateMachineResultSetter, tpd.unitLiteral),
-                tpd.DefDef(continuationStateMachineLabelSetter, tpd.unitLiteral),
-                invokeSuspendMethod
+                .Assign(continuationsStateMachineThis.select(resultVarName), paramss.head.head),
+              tpd.Assign(
+                continuationsStateMachineLabelSelect,
+                continuationsStateMachineLabelSelect.select(integerOR).appliedTo(integerMin)
               )
-            ).flatten
+            ),
+            ref(transformedMethod.symbol).appliedToTermArgs(
+              List.fill(numTransformedMethodOriginalParams)(nullLiteral) :+
+                continuationsStateMachineThis
+                  .select(nme.asInstanceOf_)
+                  .appliedToType(continuationClassRef.appliedTo(returnType))
+            )
           )
-        end continuationStateMachineClass
+      )
 
-        def transformSuspendTree(newParent: Symbol) =
-          val $continuation = tpd.ValDef(
-            newSymbol(
-              newParent,
-              termName("$continuation"),
-              Local | Mutable | Synthetic,
-              OrType(
-                continuationClassRef.appliedTo(anyType),
-                defn.NullType,
-                soft = false)).entered,
-            nullLiteral
+      ClassDefWithParents(
+        continuationsStateMachineSymbol,
+        continuationsStateMachineConstructor,
+        List(
+          tpd
+            .New(ref(continuationImplClass))
+            .select(nme.CONSTRUCTOR)
+            .appliedTo(
+              ref($completion),
+              ref($completion).select(termName("context"))
+            )),
+        List(
+          continuationStateMachineI$Ns,
+          continuationStateMachineI$Ns.map(toContFsmSetter),
+          List(
+            continuationStateMachineResult,
+            continuationStateMachineLabel,
+            tpd.DefDef(continuationStateMachineResultSetter, tpd.unitLiteral),
+            tpd.DefDef(continuationStateMachineLabelSetter, tpd.unitLiteral),
+            invokeSuspendMethod
           )
+        ).flatten
+      )
+    end continuationStateMachineClass
 
-          val continuationAsStateMachineClass =
-            ref($continuation.symbol)
+    def transformSuspendTree(newParent: Symbol) =
+      val $continuation = tpd.ValDef(
+        newSymbol(
+          newParent,
+          termName("$continuation"),
+          Local | Mutable | Synthetic,
+          OrType(continuationClassRef.appliedTo(anyType), defn.NullType, soft = false)).entered,
+        nullLiteral
+      )
+
+      val continuationAsStateMachineClass =
+        ref($continuation.symbol)
+          .select(nme.asInstanceOf_)
+          .appliedToType(continuationStateMachineClass.tpe)
+
+      val case11Param =
+        newSymbol(newParent, nme.x_0, Flags.Case | Flags.CaseAccessor, defn.AnyType).entered
+      val $continuationLabel =
+        continuationAsStateMachineClass.select(labelVarParam)
+      val case11 = tpd.CaseDef(
+        tpd.Bind(case11Param, tpd.EmptyTree),
+        ref(case11Param)
+          .select(nme.isInstanceOf_)
+          .appliedToType(continuationStateMachineClass.tpe)
+          .select(defn.Boolean_&&)
+          .appliedTo(
+            ref(case11Param)
               .select(nme.asInstanceOf_)
               .appliedToType(continuationStateMachineClass.tpe)
-
-          val case11Param =
-            newSymbol(newParent, nme.x_0, Flags.Case | Flags.CaseAccessor, defn.AnyType).entered
-          val $continuationLabel =
-            continuationAsStateMachineClass.select(labelVarParam)
-          val case11 = tpd.CaseDef(
-            tpd.Bind(case11Param, tpd.EmptyTree),
-            ref(case11Param)
-              .select(nme.isInstanceOf_)
-              .appliedToType(continuationStateMachineClass.tpe)
-              .select(defn.Boolean_&&)
-              .appliedTo(
-                ref(case11Param)
-                  .select(nme.asInstanceOf_)
-                  .appliedToType(continuationStateMachineClass.tpe)
-                  .select(labelVarParam)
-                  .select(integerAND)
-                  .appliedTo(integerMin)
-                  .select(integerNE)
-                  .appliedTo(tpd.Literal(Constant(0x0)))),
-            tpd.Block(
-              List(
-                tpd.Assign(
-                  ref($continuation.symbol),
-                  ref(case11Param)
-                    .select(nme.asInstanceOf_)
-                    .appliedToType(continuationStateMachineClass.tpe))),
-              tpd.Assign(
-                $continuationLabel,
-                $continuationLabel.select(defn.Int_-).appliedTo(integerMin))
-            )
-          )
-
-          val case12 = tpd.CaseDef(
-            Underscore(anyType),
-            tpd.EmptyTree,
+              .select(labelVarParam)
+              .select(integerAND)
+              .appliedTo(integerMin)
+              .select(integerNE)
+              .appliedTo(tpd.Literal(Constant(0x0)))),
+        tpd.Block(
+          List(
             tpd.Assign(
               ref($continuation.symbol),
-              tpd
-                .New(tpd.TypeTree(continuationStateMachineClass.tpe))
-                .select(nme.CONSTRUCTOR)
-                .appliedTo(
-                  transformedMethodCompletionParam
-                    .select(nme.asInstanceOf_)
-                    .appliedToType(
-                      continuationClassRef.appliedTo(anyOrNullType)
-                    ))
-            )
+              ref(case11Param)
+                .select(nme.asInstanceOf_)
+                .appliedToType(continuationStateMachineClass.tpe))),
+          tpd.Assign(
+            $continuationLabel,
+            $continuationLabel.select(defn.Int_-).appliedTo(integerMin))
+        )
+      )
+
+      val case12 = tpd.CaseDef(
+        Underscore(anyType),
+        tpd.EmptyTree,
+        tpd.Assign(
+          ref($continuation.symbol),
+          tpd
+            .New(tpd.TypeTree(continuationStateMachineClass.tpe))
+            .select(nme.CONSTRUCTOR)
+            .appliedTo(
+              transformedMethodCompletionParam
+                .select(nme.asInstanceOf_)
+                .appliedToType(
+                  continuationClassRef.appliedTo(anyOrNullType)
+                ))
+        )
+      )
+
+      val completionMatch =
+        tpd.Match(transformedMethodCompletionParam, List(case11, case12))
+
+      val $result =
+        tpd.ValDef(
+          newSymbol(
+            newParent,
+            termName("$result"),
+            Local,
+            eitherThrowableAnyNullSuspendedType).entered,
+          continuationAsStateMachineClass.select(resultVarName)
+        )
+
+      val undecidedState =
+        ref(continuationModule).select(termName("State")).select(termName("Undecided"))
+
+      def throwOnFailure =
+        tpd.If(
+          ref($result.symbol).select(nme.NotEquals).appliedTo(nullLiteral),
+          ref($result.symbol)
+            .select(termName("fold"))
+            .appliedToType(defn.UnitType)
+            .appliedTo(
+              tpd.Closure(
+                newAnonFun(
+                  newParent,
+                  MethodType(List(defn.ThrowableType))(_ => defn.NothingType)),
+                trees => tpd.Throw(trees.head.head)),
+              tpd.Closure(
+                newAnonFun(
+                  newParent,
+                  MethodType(List(anyNullSuspendedType))(_ => defn.UnitType)),
+                _ => unitLiteral)
+            ),
+          unitLiteral
+        )
+
+      val labels: List[Symbol] =
+        rowsBeforeSuspensionPoint.keySet.toList.indices.toList.map { i =>
+          newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType).entered
+        }
+
+      def paramsAndRowsBeforeSuspendIncludingSuspend(index: Int) =
+        transformedMethodParamsAsVals ++
+          rowsBeforeSuspensionPoint
+            .take(index + 1)
+            .transform { (suspend, rowsBefore) => rowsBefore :+ suspend }
+            .values
+            .toList
+            .flatten
+
+      def treesToAssignToI$Ns(
+          paramsAndRowsBeforeSuspendIncludingSuspend: List[tpd.Tree]): List[tpd.Tree] =
+        (transformedMethodParamsAsVals ++ globalVars)
+          .filter { v =>
+            paramsAndRowsBeforeSuspendIncludingSuspend
+              .dropRight(1)
+              .exists(_.symbol.denot.matches(v.symbol))
+          }
+          .sortWith { (t1, t2) =>
+            paramsAndRowsBeforeSuspendIncludingSuspend.indexOf(t1) >
+              paramsAndRowsBeforeSuspendIncludingSuspend.indexOf(t2)
+          }
+
+      def toCase(suspension: tpd.Tree, rowsBefore: List[tpd.Tree], i: Int): tpd.CaseDef = {
+        val label =
+          if (i > 0) tpd.Labeled(labels(i).asTerm, tpd.EmptyTree) else tpd.EmptyTree
+
+        val returnToLabel =
+          if (suspensionPointsSize > 1 && i < suspensionPointsSize - 1)
+            tpd.Return(unitLiteral, labels(i + 1))
+          else
+            tpd.EmptyTree
+
+        val callSuspensionPoint: tpd.Tree = suspension match
+          case vd: tpd.ValDef if vd.rhs.isInstanceOf[tpd.Inlined] =>
+            new TreeTypeMap(
+              oldOwners = List(parent),
+              newOwners = List(newParent),
+              substFrom = List(parent),
+              substTo = List(newParent)
+            ).transform(vd.rhs.asInstanceOf[tpd.Inlined].call)
+          case tpd.Inlined(call, _, _) =>
+            new TreeTypeMap(
+              oldOwners = List(parent),
+              newOwners = List(newParent),
+              substFrom = List(parent),
+              substTo = List(newParent)
+            ).transform(call)
+          case _ => tpd.EmptyTree
+
+        val safeContinuation: tpd.ValDef = {
+          val suspendContinuationType = callSuspensionPoint.tpe
+
+          val interceptedCall =
+            ref(interceptedMethod)
+              .appliedToType(suspendContinuationType)
+              .appliedTo(ref($continuation.symbol))
+              .appliedToNone
+
+          val safeContinuationConstructor =
+            tpd
+              .New(ref(safeContinuationClass))
+              .select(nme.CONSTRUCTOR)
+              .appliedToType(suspendContinuationType)
+              .appliedTo(interceptedCall, undecidedState)
+
+          tpd.ValDef(
+            newSymbol(
+              newParent,
+              termName("safeContinuation"),
+              Flags.Local,
+              safeContinuationConstructor.tpe).entered,
+            safeContinuationConstructor)
+        }
+
+        val safeContinuationRef = ref(safeContinuation.symbol)
+
+        val suspendContinuationBody =
+          transformSuspendContinuationBody(callSuspensionPoint, safeContinuationRef)
+
+        /*
+         ```
+         val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
+           safeContinuation.getOrThrow()
+         ```
+         */
+        val suspendContinuationGetThrow =
+          tpd.ValDef(
+            newSymbol(
+              newParent,
+              termName("orThrow"),
+              Flags.Local,
+              anyNullSuspendedType).entered,
+            safeContinuationRef.select(termName("getOrThrow")).appliedToNone)
+
+        val assignGetOrThrowToGlobalVar =
+          rowsBeforeSuspensionPoint.keySet.toList(i) match
+            case vd: tpd.ValDef =>
+              tpd.Assign(
+                globalVars.find(matchesNameCoord(_, vd)).get,
+                ref(suspendContinuationGetThrow.symbol)
+                  .select(nme.asInstanceOf_)
+                  .appliedToType(vd.symbol.info)
+              )
+            case _ =>
+              tpd.EmptyTree
+
+        def assignGlobalVarResult(vd: tpd.ValDef): tpd.Assign =
+          tpd.Assign(
+            globalVars.find(matchesNameCoord(_, vd)).get,
+            ref($result.symbol).select(nme.asInstanceOf_).appliedToType(vd.symbol.info)
           )
 
-          val completionMatch =
-            tpd.Match(transformedMethodCompletionParam, List(case11, case12))
+        val assignResultToGlobalVar =
+          rowsBeforeSuspensionPoint.keySet.toList.lift(i - 1) match
+            case Some(vd: tpd.ValDef) => assignGlobalVarResult(vd)
+            case _ => tpd.EmptyTree
 
-          val $result =
-            tpd.ValDef(
-              newSymbol(
-                newParent,
-                termName("$result"),
-                Local,
-                eitherThrowableAnyNullSuspendedType).entered,
-              continuationAsStateMachineClass.select(resultVarName)
+        /*
+         ```
+         if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
+         ````
+         */
+        val ifOrThrowReturn =
+          tpd.If(
+            ref(suspendContinuationGetThrow.symbol)
+              .select(nme.Equals)
+              .appliedTo(suspendedState),
+            tpd.Return(suspendedState, newParent),
+            tpd.EmptyTree
+          )
+
+        val paramsAndRowsBeforeSuspendIncludingSuspendCurrent =
+          paramsAndRowsBeforeSuspendIncludingSuspend(i)
+
+        def assignToI(tree: tpd.Tree, i: Int): tpd.Assign =
+          tpd.Assign(
+            continuationAsStateMachineClass.select(continuationStateMachineI$Ns(i).symbol),
+            ref(tree.symbol))
+
+        val assignToI$Ns =
+          treesToAssignToI$Ns(paramsAndRowsBeforeSuspendIncludingSuspendCurrent)
+            .zipWithIndex
+            .map(assignToI)
+
+        val relevantParamsAndRows =
+          paramsAndRowsBeforeSuspendIncludingSuspendCurrent
+            .reverse
+            .drop(1)
+            .dropWhile(r => !treeCallsSuspend(r) && !valDefTreeCallsSuspend(r))
+            .drop(1)
+
+        def keepAssign(assign: tpd.Assign): Boolean =
+          relevantParamsAndRows.exists(_.symbol.denot.matches(assign.lhs.symbol))
+
+        val assignFromI$Ns =
+          assignToI$Ns.map(a => tpd.Assign(a.rhs, a.lhs)).filter(keepAssign)
+
+        def updateForGlobalVars(tree: tpd.Tree): tpd.Tree =
+          tree match
+            case vd: tpd.ValDef =>
+              globalVars
+                .find(_.symbol.denot.matches(vd.symbol))
+                .fold(vd)(gv => tpd.Assign(ref(gv.symbol), vd.rhs))
+            case _ => tree
+
+        val stats: List[tpd.Tree] = List(
+          assignFromI$Ns,
+          List(throwOnFailure),
+          List(assignResultToGlobalVar),
+          List(label),
+          rowsBefore.map(updateForGlobalVars),
+          assignToI$Ns,
+          List(
+            tpd.Assign(
+              continuationAsStateMachineClass.select(labelVarParam),
+              tpd.Literal(Constant(i + 1))
             )
+          ),
+          List(safeContinuation),
+          suspendContinuationBody,
+          List(suspendContinuationGetThrow),
+          List(ifOrThrowReturn),
+          List(assignGetOrThrowToGlobalVar),
+          List(returnToLabel)
+        ).flatten
 
-          val undecidedState =
-            ref(continuationModule).select(termName("State")).select(termName("Undecided"))
+        val resultValue =
+          if (i == suspensionPointsSize - 1 && suspensionInReturnedValue)
+            ref(suspendContinuationGetThrow.symbol)
+          else unitLiteral
 
-          def throwOnFailure =
-            tpd.If(
-              ref($result.symbol).select(nme.NotEquals).appliedTo(nullLiteral),
-              ref($result.symbol)
-                .select(termName("fold"))
-                .appliedToType(defn.UnitType)
-                .appliedTo(
-                  tpd.Closure(
-                    newAnonFun(
-                      newParent,
-                      MethodType(List(defn.ThrowableType))(_ => defn.NothingType)),
-                    trees => tpd.Throw(trees.head.head)),
-                  tpd.Closure(
-                    newAnonFun(
-                      newParent,
-                      MethodType(List(anyNullSuspendedType))(_ => defn.UnitType)),
-                    _ => unitLiteral)
-                ),
-              unitLiteral
+        tpd.CaseDef(tpd.Literal(Constant(i)), tpd.EmptyTree, tpd.Block(stats, resultValue))
+      }
+
+      val cases =
+        rowsBeforeSuspensionPoint.zipWithIndex.toList.map {
+          case ((suspension, rowsBefore), i) => toCase(suspension, rowsBefore, i)
+        }
+
+      val case2BeforeDefault = tpd.CaseDef(
+        tpd.Literal(Constant(suspensionPointsSize)),
+        tpd.EmptyTree,
+        tpd.Block(
+          treesToAssignToI$Ns {
+            paramsAndRowsBeforeSuspendIncludingSuspend(suspensionPoints.size - 1)
+          }.zipWithIndex.map { (tree, i) =>
+            tpd.Assign(
+              ref(tree.symbol),
+              continuationAsStateMachineClass.select(continuationStateMachineI$Ns(i).symbol)
             )
-
-          val labels: List[Symbol] =
-            rowsBeforeSuspensionPoint.keySet.toList.indices.toList.map { i =>
-              newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType).entered
-            }
-
-          def paramsAndRowsBeforeSuspendIncludingSuspend(index: Int) =
-            transformedMethodParamsAsVals ++
-              rowsBeforeSuspensionPoint
-                .take(index + 1)
-                .transform { (suspend, rowsBefore) => rowsBefore :+ suspend }
-                .values
-                .toList
-                .flatten
-
-          def treesToAssignToI$Ns(
-              paramsAndRowsBeforeSuspendIncludingSuspend: List[tpd.Tree]): List[tpd.Tree] =
-            (transformedMethodParamsAsVals ++ globalVars)
-              .filter { v =>
-                paramsAndRowsBeforeSuspendIncludingSuspend
-                  .dropRight(1)
-                  .exists(_.symbol.denot.matches(v.symbol))
-              }
-              .sortWith { (t1, t2) =>
-                paramsAndRowsBeforeSuspendIncludingSuspend.indexOf(t1) >
-                  paramsAndRowsBeforeSuspendIncludingSuspend.indexOf(t2)
-              }
-
-          def toCase(suspension: tpd.Tree, rowsBefore: List[tpd.Tree], i: Int): tpd.CaseDef = {
-            val label =
-              if (i > 0) tpd.Labeled(labels(i).asTerm, tpd.EmptyTree) else tpd.EmptyTree
-
-            val returnToLabel =
-              if (suspensionPointsSize > 1 && i < suspensionPointsSize - 1)
-                tpd.Return(unitLiteral, labels(i + 1))
-              else
-                tpd.EmptyTree
-
-            val callSuspensionPoint: tpd.Tree = suspension match
-              case vd: tpd.ValDef if vd.rhs.isInstanceOf[tpd.Inlined] =>
-                new TreeTypeMap(
-                  oldOwners = List(parent),
-                  newOwners = List(newParent),
-                  substFrom = List(parent),
-                  substTo = List(newParent)
-                ).transform(vd.rhs.asInstanceOf[tpd.Inlined].call)
-              case tpd.Inlined(call, _, _) =>
-                new TreeTypeMap(
-                  oldOwners = List(parent),
-                  newOwners = List(newParent),
-                  substFrom = List(parent),
-                  substTo = List(newParent)
-                ).transform(call)
-              case _ => tpd.EmptyTree
-
-            val safeContinuation: tpd.ValDef = {
-              val suspendContinuationType = callSuspensionPoint.tpe
-
-              val interceptedCall =
-                ref(interceptedMethod)
-                  .appliedToType(suspendContinuationType)
-                  .appliedTo(ref($continuation.symbol))
-                  .appliedToNone
-
-              val safeContinuationConstructor =
-                tpd
-                  .New(ref(safeContinuationClass))
-                  .select(nme.CONSTRUCTOR)
-                  .appliedToType(suspendContinuationType)
-                  .appliedTo(interceptedCall, undecidedState)
-
-              tpd.ValDef(
-                newSymbol(
-                  newParent,
-                  termName("safeContinuation"),
-                  Flags.Local,
-                  safeContinuationConstructor.tpe).entered,
-                safeContinuationConstructor)
-            }
-
-            val safeContinuationRef = ref(safeContinuation.symbol)
-
-            val suspendContinuationBody =
-              transformSuspendContinuationBody(callSuspensionPoint, safeContinuationRef)
-
-            /*
-             ```
-             val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
-               safeContinuation.getOrThrow()
-             ```
-             */
-            val suspendContinuationGetThrow =
-              tpd.ValDef(
-                newSymbol(
-                  newParent,
-                  termName("orThrow"),
-                  Flags.Local,
-                  anyNullSuspendedType).entered,
-                safeContinuationRef.select(termName("getOrThrow")).appliedToNone)
-
-            val assignGetOrThrowToGlobalVar =
-              rowsBeforeSuspensionPoint.keySet.toList(i) match
-                case vd: tpd.ValDef =>
-                  tpd.Assign(
-                    globalVars.find(matchesNameCoord(_, vd)).get,
-                    ref(suspendContinuationGetThrow.symbol)
-                      .select(nme.asInstanceOf_)
-                      .appliedToType(vd.symbol.info)
-                  )
-                case _ =>
-                  tpd.EmptyTree
-
-            def assignGlobalVarResult(vd: tpd.ValDef): tpd.Assign =
+          } ++
+            List(throwOnFailure),
+          suspensionPoints.lastOption match
+            case Some(vd: tpd.ValDef) =>
               tpd.Assign(
                 globalVars.find(matchesNameCoord(_, vd)).get,
                 ref($result.symbol).select(nme.asInstanceOf_).appliedToType(vd.symbol.info)
               )
-
-            val assignResultToGlobalVar =
-              rowsBeforeSuspensionPoint.keySet.toList.lift(i - 1) match
-                case Some(vd: tpd.ValDef) => assignGlobalVarResult(vd)
-                case _ => tpd.EmptyTree
-
-            /*
-             ```
-             if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
-             ````
-             */
-            val ifOrThrowReturn =
-              tpd.If(
-                ref(suspendContinuationGetThrow.symbol)
-                  .select(nme.Equals)
-                  .appliedTo(suspendedState),
-                tpd.Return(suspendedState, newParent),
-                tpd.EmptyTree
-              )
-
-            val paramsAndRowsBeforeSuspendIncludingSuspendCurrent =
-              paramsAndRowsBeforeSuspendIncludingSuspend(i)
-
-            def assignToI(tree: tpd.Tree, i: Int): tpd.Assign =
-              tpd.Assign(
-                continuationAsStateMachineClass.select(continuationStateMachineI$Ns(i).symbol),
-                ref(tree.symbol))
-
-            val assignToI$Ns =
-              treesToAssignToI$Ns(paramsAndRowsBeforeSuspendIncludingSuspendCurrent)
-                .zipWithIndex
-                .map(assignToI)
-
-            val relevantParamsAndRows =
-              paramsAndRowsBeforeSuspendIncludingSuspendCurrent
-                .reverse
-                .drop(1)
-                .dropWhile(r => !treeCallsSuspend(r) && !valDefTreeCallsSuspend(r))
-                .drop(1)
-
-            def keepAssign(assign: tpd.Assign): Boolean =
-              relevantParamsAndRows.exists(_.symbol.denot.matches(assign.lhs.symbol))
-
-            val assignFromI$Ns =
-              assignToI$Ns.map(a => tpd.Assign(a.rhs, a.lhs)).filter(keepAssign)
-
-            def updateForGlobalVars(tree: tpd.Tree): tpd.Tree =
-              tree match
-                case vd: tpd.ValDef =>
-                  globalVars
-                    .find(_.symbol.denot.matches(vd.symbol))
-                    .fold(vd)(gv => tpd.Assign(ref(gv.symbol), vd.rhs))
-                case _ => tree
-
-            val stats: List[tpd.Tree] = List(
-              assignFromI$Ns,
-              List(throwOnFailure),
-              List(assignResultToGlobalVar),
-              List(label),
-              rowsBefore.map(updateForGlobalVars),
-              assignToI$Ns,
-              List(
-                tpd.Assign(
-                  continuationAsStateMachineClass.select(labelVarParam),
-                  tpd.Literal(Constant(i + 1))
-                )
-              ),
-              List(safeContinuation),
-              suspendContinuationBody,
-              List(suspendContinuationGetThrow),
-              List(ifOrThrowReturn),
-              List(assignGetOrThrowToGlobalVar),
-              List(returnToLabel)
-            ).flatten
-
-            val resultValue =
-              if (i == suspensionPointsSize - 1 && suspensionInReturnedValue)
-                ref(suspendContinuationGetThrow.symbol)
-              else unitLiteral
-
-            tpd.CaseDef(tpd.Literal(Constant(i)), tpd.EmptyTree, tpd.Block(stats, resultValue))
-          }
-
-          val cases =
-            rowsBeforeSuspensionPoint.zipWithIndex.toList.map {
-              case ((suspension, rowsBefore), i) => toCase(suspension, rowsBefore, i)
-            }
-
-          val case2BeforeDefault = tpd.CaseDef(
-            tpd.Literal(Constant(suspensionPointsSize)),
-            tpd.EmptyTree,
-            tpd.Block(
-              treesToAssignToI$Ns {
-                paramsAndRowsBeforeSuspendIncludingSuspend(suspensionPoints.size - 1)
-              }.zipWithIndex.map { (tree, i) =>
-                tpd.Assign(
-                  ref(tree.symbol),
-                  continuationAsStateMachineClass.select(continuationStateMachineI$Ns(i).symbol)
-                )
-              } ++
-                List(throwOnFailure),
-              suspensionPoints.lastOption match
-                case Some(vd: tpd.ValDef) =>
-                  tpd.Assign(
-                    globalVars.find(matchesNameCoord(_, vd)).get,
-                    ref($result.symbol).select(nme.asInstanceOf_).appliedToType(vd.symbol.info)
-                  )
-                case Some(_) if suspensionInReturnedValue => ref($result.symbol)
-                case _ => unitLiteral
-            )
-          )
-
-          val labelMatch = tpd
-            .Match(
-              continuationAsStateMachineClass.select(labelVarParam),
-              cases ++ List(case2BeforeDefault, resumeDefaultCaseError)
-            )
-            .withType(anyNullSuspendedType)
-
-          tpd.Block(List($continuation, completionMatch, $result), labelMatch)
-        end transformSuspendTree
-
-        val transformedMethodParamSymbols: List[Symbol] =
-          transformedMethodSymbol.paramSymss.flatMap(_.filterNot(hasContinuationClass))
-
-        val oldMethodParamSymbols: List[Symbol] =
-          tree.symbol.paramSymss.flatten.filterNot(s => hasSuspendClass(s) || s.isTypeParam)
-
-        /**
-         * If there are more that one Suspension points we create the whole state machine for
-         * all the points and replace the last occurrence of `suspendContinuation`. The other
-         * occurrences are not needed and are being removed.
-         *
-         * We also don't need to keep the rest of the lines before the last
-         * `suspendContinuation` as they are embedded in the state machine.
-         */
-        var c = 0
-        var rowsToRemove = rowsBeforeSuspensionPoint.values.toList.flatten.map(_.symbol.coord)
-        val substituteContinuation = new TreeTypeMap(
-          treeMap = {
-            case tree if valDefTreeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
-              c += 1
-              tpd.EmptyTree
-            case tree if valDefTreeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
-              transformSuspendTree(transformedMethod.symbol)
-            case tree if treeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
-              c += 1
-              tpd.EmptyTree
-            case tree if treeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
-              transformSuspendTree(transformedMethod.symbol)
-            case tree if c < suspensionPointsSize && rowsToRemove.contains(tree.symbol.coord) =>
-              rowsToRemove = rowsToRemove.zipWithIndex.collect {
-                case (coord, index) if index != rowsToRemove.indexOf(tree.symbol.coord) =>
-                  coord
-              }
-              tpd.EmptyTree
-            case tree if globalVars.exists(matchesNameCoord(_, tree)) =>
-              ref(globalVars.find(matchesNameCoord(_, tree)).get.symbol)
-            case tt
-                if tt.symbol.exists &&
-                  tt.symbol.is(TermParam) &&
-                  tt.symbol.owner.denot.matches(tree.symbol) &&
-                  transformedMethodParamsWithoutCompletion.exists(
-                    _.symbol.denot.matches(tt.symbol)) &&
-                  transformedMethodParamsAsVals.exists(
-                    _.symbol.name.show.dropRight(3) == tt.symbol.name.show) =>
-              ref(
-                transformedMethodParamsAsVals
-                  .find(_.symbol.name.show.dropRight(3) == tt.symbol.name.show)
-                  .get
-                  .symbol)
-            case tree =>
-              tree
-          },
-          substFrom = List(parent) ++ oldMethodParamSymbols ++ contextFunctionOwner.toList,
-          substTo = List(transformedMethod.symbol) ++ transformedMethodParamSymbols ++
-            List(transformedMethod.symbol),
-          oldOwners = List(parent) ++ contextFunctionOwner.toList,
-          newOwners = List(transformedMethod.symbol, transformedMethod.symbol)
+            case Some(_) if suspensionInReturnedValue => ref($result.symbol)
+            case _ => unitLiteral
         )
+      )
 
-        val transformedMethodBody =
-          substituteContinuation.transform(rhs) match
-            case Trees.Block(stats, expr) =>
-              val allStats = transformedMethodParamsAsVals ++ globalVars ++ stats
-              flattenBlock(tpd.Block(allStats, expr))
-            case tree => tree
+      val labelMatch = tpd
+        .Match(
+          continuationAsStateMachineClass.select(labelVarParam),
+          cases ++ List(case2BeforeDefault, resumeDefaultCaseError)
+        )
+        .withType(anyNullSuspendedType)
 
-        val transformedTree =
-          tpd.Thicket(
-            continuationStateMachineClass ::
-              cpy.DefDef(transformedMethod)(rhs = transformedMethodBody) ::
-              Nil)
+      tpd.Block(List($continuation, completionMatch, $result), labelMatch)
+    end transformSuspendTree
 
-        report.logWith("state machine and new defdef:")(transformedTree)
+    val transformedMethodParamSymbols: List[Symbol] =
+      transformedMethodSymbol.paramSymss.flatMap(_.filterNot(hasContinuationClass))
+
+    val oldMethodParamSymbols: List[Symbol] =
+      tree.symbol.paramSymss.flatten.filterNot(s => hasSuspendClass(s) || s.isTypeParam)
+
+    /**
+     * If there are more that one Suspension points we create the whole state machine for all
+     * the points and replace the last occurrence of `suspendContinuation`. The other
+     * occurrences are not needed and are being removed.
+     *
+     * We also don't need to keep the rest of the lines before the last `suspendContinuation` as
+     * they are embedded in the state machine.
+     */
+    var c = 0
+    var rowsToRemove = rowsBeforeSuspensionPoint.values.toList.flatten.map(_.symbol.coord)
+    val substituteContinuation = new TreeTypeMap(
+      treeMap = {
+        case tree if valDefTreeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
+          c += 1
+          tpd.EmptyTree
+        case tree if valDefTreeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
+          transformSuspendTree(transformedMethod.symbol)
+        case tree if treeCallsSuspend(tree) && c < suspensionPointsSize - 1 =>
+          c += 1
+          tpd.EmptyTree
+        case tree if treeCallsSuspend(tree) && c == suspensionPointsSize - 1 =>
+          transformSuspendTree(transformedMethod.symbol)
+        case tree if c < suspensionPointsSize && rowsToRemove.contains(tree.symbol.coord) =>
+          rowsToRemove = rowsToRemove.zipWithIndex.collect {
+            case (coord, index) if index != rowsToRemove.indexOf(tree.symbol.coord) =>
+              coord
+          }
+          tpd.EmptyTree
+        case tree if globalVars.exists(matchesNameCoord(_, tree)) =>
+          ref(globalVars.find(matchesNameCoord(_, tree)).get.symbol)
+        case tt
+            if tt.symbol.exists &&
+              tt.symbol.is(TermParam) &&
+              tt.symbol.owner.denot.matches(tree.symbol) &&
+              transformedMethodParamsWithoutCompletion.exists(
+                _.symbol.denot.matches(tt.symbol)) &&
+              transformedMethodParamsAsVals.exists(
+                _.symbol.name.show.dropRight(3) == tt.symbol.name.show) =>
+          ref(
+            transformedMethodParamsAsVals
+              .find(_.symbol.name.show.dropRight(3) == tt.symbol.name.show)
+              .get
+              .symbol)
+        case tree =>
+          tree
+      },
+      substFrom = List(parent) ++ oldMethodParamSymbols ++ contextFunctionOwner.toList,
+      substTo = List(transformedMethod.symbol) ++ transformedMethodParamSymbols ++
+        List(transformedMethod.symbol),
+      oldOwners = List(parent) ++ contextFunctionOwner.toList,
+      newOwners = List(transformedMethod.symbol, transformedMethod.symbol)
+    )
+
+    val transformedMethodBody =
+      substituteContinuation.transform(rhs) match
+        case Trees.Block(stats, expr) =>
+          val allStats = transformedMethodParamsAsVals ++ globalVars ++ stats
+          flattenBlock(tpd.Block(allStats, expr))
+        case tree => tree
+
+    tpd.Thicket(
+      continuationStateMachineClass ::
+        cpy.DefDef(transformedMethod)(rhs = transformedMethodBody) ::
+        Nil)
+
+  end transformSuspensionsSuspendingStateMachineAux


### PR DESCRIPTION
Reduces inlining of the last method