### PR TITLE
Extract "checkResult" procedure in generated code.

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/Continuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Continuation.scala
@@ -13,6 +13,15 @@ object Continuation:
   enum State:
     case Suspended, Undecided, Resumed
 
+  type Result = Either[Throwable, Any | Null | State.Suspended.type]
+
+  def checkResult(result: Result): Unit =
+    result match {
+      case null => ()
+      case Left(ex) => throw ex
+      case Right(_) => ()
+    }
+
 abstract class RestrictedContinuation(
     completion: Continuation[Any | Null] | Null
 ) extends BaseContinuationImpl(completion):

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -929,7 +929,7 @@ object DefDefTransforms extends TreesChecks:
 
       val checkResultSym: TermSymbol = newSymbol(
         transformedMethodSymbol,
-        termName("checkResult"),
+        termName("$checkResult"),
         Local,
         defn.UnitType).entered
 

--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -915,39 +915,65 @@ object DefDefTransforms extends TreesChecks:
       val completionMatch =
         tpd.Match(transformedMethodCompletionParam, List(case11, case12))
 
-      val $result =
-        tpd.ValDef(
-          newSymbol(
-            newParent,
-            termName("$result"),
-            Local,
-            eitherThrowableAnyNullSuspendedType).entered,
-          continuationAsStateMachineClass.select(resultVarName)
-        )
+      val resultSym: TermSymbol =
+        newSymbol(
+          newParent,
+          termName("$result"),
+          Local,
+          eitherThrowableAnyNullSuspendedType).entered
+
+      val $result = tpd.ValDef(resultSym, continuationAsStateMachineClass.select(resultVarName))
 
       val undecidedState =
         ref(continuationModule).select(termName("State")).select(termName("Undecided"))
 
-      def throwOnFailure =
-        tpd.If(
-          ref($result.symbol).select(nme.NotEquals).appliedTo(nullLiteral),
-          ref($result.symbol)
-            .select(termName("fold"))
-            .appliedToType(defn.UnitType)
-            .appliedTo(
-              tpd.Closure(
-                newAnonFun(
-                  newParent,
-                  MethodType(List(defn.ThrowableType))(_ => defn.NothingType)),
-                trees => tpd.Throw(trees.head.head)),
-              tpd.Closure(
-                newAnonFun(
-                  newParent,
-                  MethodType(List(anyNullSuspendedType))(_ => defn.UnitType)),
-                _ => unitLiteral)
-            ),
-          unitLiteral
-        )
+      val checkResultSym: TermSymbol = newSymbol(
+        transformedMethodSymbol,
+        termName("checkResult"),
+        Local,
+        defn.UnitType).entered
+
+      /*
+       ```
+       def checkResult: Unit =
+         if $result.!=(null) then
+           $result.fold[Unit](
+             {
+               def $anonfun(x$0: Throwable): Nothing = throw x$0
+               closure($anonfun)
+             }
+           ,
+             {
+               def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+               closure($anonfun)
+             }
+           )
+         else ()
+       ```
+       */
+      val checkResultDef: tpd.DefDef = {
+        val throwOnFailure =
+          tpd.If(
+            ref($result.symbol).select(nme.NotEquals).appliedTo(nullLiteral),
+            ref($result.symbol)
+              .select(termName("fold"))
+              .appliedToType(defn.UnitType)
+              .appliedTo(
+                tpd.Closure(
+                  newAnonFun(
+                    newParent,
+                    MethodType(List(defn.ThrowableType))(_ => defn.NothingType)),
+                  trees => tpd.Throw(trees.head.head)),
+                tpd.Closure(
+                  newAnonFun(
+                    newParent,
+                    MethodType(List(anyNullSuspendedType))(_ => defn.UnitType)),
+                  _ => unitLiteral)
+              ),
+            unitLiteral
+          )
+        tpd.DefDef(checkResultSym, Nil, defn.UnitType, throwOnFailure)
+      }
 
       val labels: List[Symbol] =
         rowsBeforeSuspensionPoint.keySet.toList.indices.toList.map { i =>
@@ -1121,7 +1147,7 @@ object DefDefTransforms extends TreesChecks:
 
         val stats: List[tpd.Tree] = List(
           assignFromI$Ns,
-          List(throwOnFailure),
+          List(ref(checkResultSym)),
           List(assignResultToGlobalVar),
           List(label),
           rowsBefore.map(updateForGlobalVars),
@@ -1165,7 +1191,7 @@ object DefDefTransforms extends TreesChecks:
               continuationAsStateMachineClass.select(continuationStateMachineI$Ns(i).symbol)
             )
           } ++
-            List(throwOnFailure),
+            List(ref(checkResultSym)),
           suspensionPoints.lastOption match
             case Some(vd: tpd.ValDef) =>
               tpd.Assign(
@@ -1184,7 +1210,7 @@ object DefDefTransforms extends TreesChecks:
         )
         .withType(anyNullSuspendedType)
 
-      tpd.Block(List($continuation, completionMatch, $result), labelMatch)
+      tpd.Block(List($continuation, completionMatch, $result, checkResultDef), labelMatch)
     end transformSuspendTree
 
     val transformedMethodParamSymbols: List[Symbol] =

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -73,24 +73,10 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def $checkResult: Unit = 
-       |                if $result.!=(null) then 
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  , 
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -102,7 +88,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 1 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -164,24 +150,10 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def $checkResult: Unit = 
-       |                if $result.!=(null) then 
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  , 
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    $continuation.asInstanceOf[program$foo$1].I$0 = x##1
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -195,7 +167,7 @@ trait StateMachineFixtures {
        |                    ()
        |                  case 1 => 
        |                    x##1 = $continuation.asInstanceOf[program$foo$1].I$0
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -254,24 +226,10 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def $checkResult: Unit = 
-       |                if $result.!=(null) then 
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  , 
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -284,7 +242,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    label1[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
@@ -298,7 +256,7 @@ trait StateMachineFixtures {
        |                    return[label2] ()
        |                    ()
        |                  case 2 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    label2[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
@@ -311,7 +269,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 3 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -370,24 +328,10 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def $checkResult: Unit = 
-       |                if $result.!=(null) then 
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  , 
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -402,7 +346,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    label1[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
@@ -417,7 +361,7 @@ trait StateMachineFixtures {
        |                    return[label2] ()
        |                    ()
        |                  case 2 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    label2[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
@@ -432,7 +376,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 3 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -491,24 +435,10 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def $checkResult: Unit = 
-       |                if $result.!=(null) then 
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  , 
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    println("Start")
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -522,7 +452,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    label1[Unit]: <empty>
        |                    val x: String = "World"
        |                    println("Hello")
@@ -538,7 +468,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 2 => 
-       |                    $checkResult
+       |                    continuations.Continuation.checkResult($result)
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -597,24 +527,10 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
-       |            def $checkResult: Unit = 
-       |              if $result.!=(null) then 
-       |                $result.fold[Unit](
-       |                  {
-       |                    def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                    closure($anonfun)
-       |                  }
-       |                , 
-       |                  {
-       |                    def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                    closure($anonfun)
-       |                  }
-       |                )
-       |               else ()
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -627,7 +543,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  label1[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
@@ -641,7 +557,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -654,7 +570,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -710,24 +626,10 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
-       |            def $checkResult: Unit = 
-       |              if $result.!=(null) then 
-       |                $result.fold[Unit](
-       |                  {
-       |                    def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                    closure($anonfun)
-       |                  }
-       |                , 
-       |                  {
-       |                    def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                    closure($anonfun)
-       |                  }
-       |                )
-       |               else ()
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -741,7 +643,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  label1[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
@@ -756,7 +658,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -769,7 +671,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -825,24 +727,10 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
-       |            def $checkResult: Unit = 
-       |              if $result.!=(null) then 
-       |                $result.fold[Unit](
-       |                  {
-       |                    def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                    closure($anonfun)
-       |                  }
-       |                , 
-       |                  {
-       |                    def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                    closure($anonfun)
-       |                  }
-       |                )
-       |               else ()
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  println("Start")
        |                  val x: Int = 1
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
@@ -857,7 +745,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  label1[Unit]: <empty>
        |                  println("Hello")
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
@@ -872,7 +760,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -885,7 +773,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  $checkResult
+       |                  continuations.Continuation.checkResult($result)
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -973,27 +861,13 @@ trait StateMachineFixtures {
        |              continuations.compileFromString$package.
        |                compileFromString$package$foo$1
        |            ].$result
-       |          def $checkResult: Unit = 
-       |            if $result.!=(null) then
-       |              $result.fold[Unit](
-       |                {
-       |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                  closure($anonfun)
-       |                }
-       |              , 
-       |                {
-       |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                  closure($anonfun)
-       |                }
-       |              )
-       |             else ()
        |          $continuation.asInstanceOf[
        |            continuations.compileFromString$package.
        |              compileFromString$package$foo$1
        |          ].$label match
        |            {
        |              case 0 =>
-       |                $checkResult
+       |                continuations.Continuation.checkResult($result)
        |                $continuation.asInstanceOf[
        |                  continuations.compileFromString$package.
        |                    compileFromString$package$foo$1
@@ -1018,7 +892,7 @@ trait StateMachineFixtures {
        |                    continuations.compileFromString$package.
        |                      compileFromString$package$foo$1
        |                  ].I$0
-       |                $checkResult
+       |                continuations.Continuation.checkResult($result)
        |                y = $result.asInstanceOf[Int]
        |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |            }
@@ -1103,27 +977,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$foo$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$foo$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$foo$1
@@ -1147,7 +1007,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  ].I$0
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1232,27 +1092,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$foo$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$foo$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                xx = 111
       |                println(xx)
       |                $continuation.asInstanceOf[
@@ -1278,7 +1124,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  ].I$0
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1383,27 +1229,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                pp = 11
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1439,7 +1271,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
@@ -1496,7 +1328,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                yy = $result.asInstanceOf[String]
       |                label2[Unit]: <empty>
       |                tt = 100
@@ -1569,7 +1401,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$5
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1672,27 +1504,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                pp = 11
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1728,7 +1546,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
@@ -1784,7 +1602,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                label2[Unit]: <empty>
       |                tt = 100
       |                $continuation.asInstanceOf[
@@ -1847,7 +1665,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1938,27 +1756,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1992,7 +1796,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val z: Int = 1
@@ -2037,7 +1841,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2123,27 +1927,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2160,7 +1950,7 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -2186,7 +1976,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2281,27 +2071,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                val z: Int = 100
       |                $continuation.asInstanceOf[
@@ -2329,7 +2105,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                j = 9
@@ -2376,7 +2152,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |                label2[Unit]: <empty>
       |                println("World")
@@ -2430,7 +2206,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2520,27 +2296,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2566,7 +2328,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -2601,7 +2363,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2699,27 +2461,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                q = 2
       |                val w: Int = 3
       |                $continuation.asInstanceOf[
@@ -2756,7 +2504,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                p = 1
@@ -2812,7 +2560,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2905,27 +2653,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2960,7 +2694,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3004,7 +2738,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3121,24 +2855,10 @@ trait StateMachineFixtures {
       |                }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
       |                $continuation.asInstanceOf[program$fooTest$1].$result
-      |              def $checkResult: Unit = 
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  , 
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
       |              $continuation.asInstanceOf[program$fooTest$1].$label match
       |                {
       |                  case 0 =>
-      |                    $checkResult
+      |                    continuations.Continuation.checkResult($result)
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
       |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
       |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
@@ -3156,7 +2876,7 @@ trait StateMachineFixtures {
       |                  case 1 =>
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    $checkResult
+      |                    continuations.Continuation.checkResult($result)
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
@@ -3183,7 +2903,7 @@ trait StateMachineFixtures {
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
       |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
-      |                    $checkResult
+      |                    continuations.Continuation.checkResult($result)
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |                }
@@ -3352,24 +3072,10 @@ trait StateMachineFixtures {
       |                }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
       |                $continuation.asInstanceOf[program$fooTest$1].$result
-      |              def $checkResult: Unit = 
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  , 
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
       |              $continuation.asInstanceOf[program$fooTest$1].$label match
       |                {
       |                  case 0 =>
-      |                    $checkResult
+      |                    continuations.Continuation.checkResult($result)
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
       |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
       |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
@@ -3387,7 +3093,7 @@ trait StateMachineFixtures {
       |                  case 1 =>
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    $checkResult
+      |                    continuations.Continuation.checkResult($result)
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
@@ -3414,7 +3120,7 @@ trait StateMachineFixtures {
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
       |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
-      |                    $checkResult
+      |                    continuations.Continuation.checkResult($result)
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |                }
@@ -3513,27 +3219,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3577,7 +3269,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3630,7 +3322,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3724,27 +3416,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3779,7 +3457,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3823,7 +3501,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3915,27 +3593,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3970,7 +3634,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4014,7 +3678,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4106,27 +3770,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -4162,7 +3812,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4206,7 +3856,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4298,27 +3948,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -4354,7 +3990,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4398,7 +4034,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4490,27 +4126,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                println("World")
       |                $continuation.asInstanceOf[
@@ -4547,7 +4169,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4591,7 +4213,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4683,27 +4305,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -4740,7 +4348,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4784,7 +4392,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4879,27 +4487,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -4945,7 +4539,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4998,7 +4592,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5093,27 +4687,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -5159,7 +4739,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5213,7 +4793,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5311,27 +4891,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -5386,7 +4952,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(1)
@@ -5449,7 +5015,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5544,27 +5110,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                val a: Int = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -5610,7 +5162,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5665,7 +5217,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5763,27 +5315,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -5838,7 +5376,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5902,7 +5440,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6000,27 +5538,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6075,7 +5599,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6139,7 +5663,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6240,27 +5764,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6315,7 +5825,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6380,7 +5890,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6482,27 +5992,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6557,7 +6053,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6622,7 +6118,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6725,27 +6221,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6800,7 +6282,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6865,7 +6347,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6968,27 +6450,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7043,7 +6511,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7108,7 +6576,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -7212,27 +6680,13 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def $checkResult: Unit = 
-      |            if $result.!=(null) then
-      |              $result.fold[Unit](
-      |                {
-      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                  closure($anonfun)
-      |                }
-      |              , 
-      |                {
-      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                  closure($anonfun)
-      |                }
-      |              )
-      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7287,7 +6741,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7351,7 +6805,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                $checkResult
+      |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -73,22 +73,24 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
+       |              def checkResult: Unit = 
+       |                if $result.!=(null) then 
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  , 
+       |                    {
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -100,19 +102,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -174,22 +164,24 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
+       |              def checkResult: Unit = 
+       |                if $result.!=(null) then 
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  , 
+       |                    {
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    $continuation.asInstanceOf[program$foo$1].I$0 = x##1
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -203,19 +195,7 @@ trait StateMachineFixtures {
        |                    ()
        |                  case 1 => 
        |                    x##1 = $continuation.asInstanceOf[program$foo$1].I$0
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -274,22 +254,24 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
+       |              def checkResult: Unit = 
+       |                if $result.!=(null) then 
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  , 
+       |                    {
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -302,19 +284,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    label1[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
@@ -328,19 +298,7 @@ trait StateMachineFixtures {
        |                    return[label2] ()
        |                    ()
        |                  case 2 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    label2[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
@@ -353,19 +311,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 3 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -424,22 +370,24 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
+       |              def checkResult: Unit = 
+       |                if $result.!=(null) then 
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  , 
+       |                    {
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -454,19 +402,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    label1[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
@@ -481,19 +417,7 @@ trait StateMachineFixtures {
        |                    return[label2] ()
        |                    ()
        |                  case 2 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    label2[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
@@ -508,19 +432,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 3 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -579,22 +491,24 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
+       |              def checkResult: Unit = 
+       |                if $result.!=(null) then 
+       |                  $result.fold[Unit](
+       |                    {
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                      closure($anonfun)
+       |                    }
+       |                  , 
+       |                    {
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      closure($anonfun)
+       |                    }
+       |                  )
+       |                 else ()
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    println("Start")
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -608,19 +522,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    label1[Unit]: <empty>
        |                    val x: String = "World"
        |                    println("Hello")
@@ -636,19 +538,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 2 => 
-       |                    if $result.!=(null) then 
-       |                      $result.fold[Unit](
-       |                        {
-       |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                          closure($anonfun)
-       |                        }
-       |                      , 
-       |                        {
-       |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                          closure($anonfun)
-       |                        }
-       |                      )
-       |                     else ()
+       |                    checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -707,22 +597,24 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
+       |            def checkResult: Unit = 
+       |              if $result.!=(null) then 
+       |                $result.fold[Unit](
+       |                  {
+       |                    def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                    closure($anonfun)
+       |                  }
+       |                , 
+       |                  {
+       |                    def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                    closure($anonfun)
+       |                  }
+       |                )
+       |               else ()
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -735,19 +627,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  label1[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
@@ -761,19 +641,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -786,19 +654,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -854,22 +710,24 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
+       |            def checkResult: Unit = 
+       |              if $result.!=(null) then 
+       |                $result.fold[Unit](
+       |                  {
+       |                    def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                    closure($anonfun)
+       |                  }
+       |                , 
+       |                  {
+       |                    def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                    closure($anonfun)
+       |                  }
+       |                )
+       |               else ()
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -883,19 +741,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  label1[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
@@ -910,19 +756,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -935,19 +769,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -1003,22 +825,24 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
+       |            def checkResult: Unit = 
+       |              if $result.!=(null) then 
+       |                $result.fold[Unit](
+       |                  {
+       |                    def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                    closure($anonfun)
+       |                  }
+       |                , 
+       |                  {
+       |                    def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                    closure($anonfun)
+       |                  }
+       |                )
+       |               else ()
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  println("Start")
        |                  val x: Int = 1
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
@@ -1033,19 +857,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  label1[Unit]: <empty>
        |                  println("Hello")
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
@@ -1060,19 +872,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -1085,19 +885,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  if $result.!=(null) then 
-       |                    $result.fold[Unit](
-       |                      {
-       |                        def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                        closure($anonfun)
-       |                      }
-       |                    , 
-       |                      {
-       |                        def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                        closure($anonfun)
-       |                      }
-       |                    )
-       |                   else ()
+       |                  checkResult
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -1185,25 +973,27 @@ trait StateMachineFixtures {
        |              continuations.compileFromString$package.
        |                compileFromString$package$foo$1
        |            ].$result
+       |          def checkResult: Unit = 
+       |            if $result.!=(null) then
+       |              $result.fold[Unit](
+       |                {
+       |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+       |                  closure($anonfun)
+       |                }
+       |              , 
+       |                {
+       |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                  closure($anonfun)
+       |                }
+       |              )
+       |             else ()
        |          $continuation.asInstanceOf[
        |            continuations.compileFromString$package.
        |              compileFromString$package$foo$1
        |          ].$label match
        |            {
        |              case 0 =>
-       |                if $result.!=(null) then
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  ,
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
+       |                checkResult
        |                $continuation.asInstanceOf[
        |                  continuations.compileFromString$package.
        |                    compileFromString$package$foo$1
@@ -1228,19 +1018,7 @@ trait StateMachineFixtures {
        |                    continuations.compileFromString$package.
        |                      compileFromString$package$foo$1
        |                  ].I$0
-       |                if $result.!=(null) then
-       |                  $result.fold[Unit](
-       |                    {
-       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-       |                      closure($anonfun)
-       |                    }
-       |                  ,
-       |                    {
-       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-       |                      closure($anonfun)
-       |                    }
-       |                  )
-       |                 else ()
+       |                checkResult
        |                y = $result.asInstanceOf[Int]
        |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |            }
@@ -1325,25 +1103,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$foo$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$foo$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$foo$1
@@ -1367,19 +1147,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  ].I$0
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1464,25 +1232,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$foo$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$foo$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                xx = 111
       |                println(xx)
       |                $continuation.asInstanceOf[
@@ -1508,19 +1278,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  ].I$0
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1625,25 +1383,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                pp = 11
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1679,19 +1439,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
@@ -1748,19 +1496,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                yy = $result.asInstanceOf[String]
       |                label2[Unit]: <empty>
       |                tt = 100
@@ -1833,19 +1569,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$5
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1948,25 +1672,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                pp = 11
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -2002,19 +1728,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
@@ -2070,19 +1784,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                label2[Unit]: <empty>
       |                tt = 100
       |                $continuation.asInstanceOf[
@@ -2145,19 +1847,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2248,25 +1938,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                println("Hello")
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -2300,19 +1992,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val z: Int = 1
@@ -2357,19 +2037,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2455,25 +2123,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2490,19 +2160,7 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -2528,19 +2186,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2635,25 +2281,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                println("Hello")
       |                val z: Int = 100
       |                $continuation.asInstanceOf[
@@ -2681,19 +2329,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                j = 9
@@ -2740,19 +2376,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                w = $result.asInstanceOf[Int]
       |                label2[Unit]: <empty>
       |                println("World")
@@ -2806,19 +2430,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2908,25 +2520,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2952,19 +2566,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -2999,19 +2601,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3109,25 +2699,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                q = 2
       |                val w: Int = 3
       |                $continuation.asInstanceOf[
@@ -3164,19 +2756,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                p = 1
@@ -3232,19 +2812,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3337,25 +2905,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3390,19 +2960,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3446,19 +3004,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3532,7 +3078,7 @@ trait StateMachineFixtures {
       |    def program: continuations.Foo =
       |      {
       |        class program$fooTest$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion
-      |          ,
+      |          , 
       |        $completion.context) {
       |          var I$0: Any = _
       |          var I$1: Any = _
@@ -3575,22 +3121,24 @@ trait StateMachineFixtures {
       |                }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
       |                $continuation.asInstanceOf[program$fooTest$1].$result
+      |              def checkResult: Unit = 
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  , 
+      |                    {
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
       |              $continuation.asInstanceOf[program$fooTest$1].$label match
       |                {
       |                  case 0 =>
-      |                    if $result.!=(null) then
-      |                      $result.fold[Unit](
-      |                        {
-      |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                          closure($anonfun)
-      |                        }
-      |                      ,
-      |                        {
-      |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                          closure($anonfun)
-      |                        }
-      |                      )
-      |                     else ()
+      |                    checkResult
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
       |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
       |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
@@ -3608,19 +3156,7 @@ trait StateMachineFixtures {
       |                  case 1 =>
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    if $result.!=(null) then
-      |                      $result.fold[Unit](
-      |                        {
-      |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                          closure($anonfun)
-      |                        }
-      |                      ,
-      |                        {
-      |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                          closure($anonfun)
-      |                        }
-      |                      )
-      |                     else ()
+      |                    checkResult
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
@@ -3647,19 +3183,7 @@ trait StateMachineFixtures {
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
       |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
-      |                    if $result.!=(null) then
-      |                      $result.fold[Unit](
-      |                        {
-      |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                          closure($anonfun)
-      |                        }
-      |                      ,
-      |                        {
-      |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                          closure($anonfun)
-      |                        }
-      |                      )
-      |                     else ()
+      |                    checkResult
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |                }
@@ -3785,7 +3309,7 @@ trait StateMachineFixtures {
       |    def program: continuations.Bar =
       |      {
       |        class program$fooTest$1($completion: continuations.Continuation[Any | Null]) extends continuations.jvm.internal.ContinuationImpl($completion
-      |          ,
+      |          , 
       |        $completion.context) {
       |          var I$0: Any = _
       |          var I$1: Any = _
@@ -3828,22 +3352,24 @@ trait StateMachineFixtures {
       |                }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
       |                $continuation.asInstanceOf[program$fooTest$1].$result
+      |              def checkResult: Unit = 
+      |                if $result.!=(null) then
+      |                  $result.fold[Unit](
+      |                    {
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                      closure($anonfun)
+      |                    }
+      |                  , 
+      |                    {
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      closure($anonfun)
+      |                    }
+      |                  )
+      |                 else ()
       |              $continuation.asInstanceOf[program$fooTest$1].$label match
       |                {
       |                  case 0 =>
-      |                    if $result.!=(null) then
-      |                      $result.fold[Unit](
-      |                        {
-      |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                          closure($anonfun)
-      |                        }
-      |                      ,
-      |                        {
-      |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                          closure($anonfun)
-      |                        }
-      |                      )
-      |                     else ()
+      |                    checkResult
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
       |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
       |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
@@ -3861,19 +3387,7 @@ trait StateMachineFixtures {
       |                  case 1 =>
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    if $result.!=(null) then
-      |                      $result.fold[Unit](
-      |                        {
-      |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                          closure($anonfun)
-      |                        }
-      |                      ,
-      |                        {
-      |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                          closure($anonfun)
-      |                        }
-      |                      )
-      |                     else ()
+      |                    checkResult
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
@@ -3900,19 +3414,7 @@ trait StateMachineFixtures {
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
       |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
-      |                    if $result.!=(null) then
-      |                      $result.fold[Unit](
-      |                        {
-      |                          def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                          closure($anonfun)
-      |                        }
-      |                      ,
-      |                        {
-      |                          def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                          closure($anonfun)
-      |                        }
-      |                      )
-      |                     else ()
+      |                    checkResult
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |                }
@@ -4011,25 +3513,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -4073,19 +3577,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4138,19 +3630,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4244,25 +3724,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -4297,19 +3779,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4353,19 +3823,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4457,25 +3915,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -4510,19 +3970,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4566,19 +4014,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4670,25 +4106,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                println("Hello")
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -4724,19 +4162,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4780,19 +4206,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4884,25 +4298,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -4938,19 +4354,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4994,19 +4398,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5098,25 +4490,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                println("Hello")
       |                println("World")
       |                $continuation.asInstanceOf[
@@ -5153,19 +4547,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -5209,19 +4591,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5313,25 +4683,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                println("Hello")
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -5368,19 +4740,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -5424,19 +4784,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5531,25 +4879,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -5595,19 +4945,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -5660,19 +4998,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5767,25 +5093,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -5831,19 +5159,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5897,19 +5213,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6007,25 +5311,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6080,19 +5386,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(1)
@@ -6155,19 +5449,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6262,25 +5544,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                val a: Int = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6326,19 +5610,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -6393,19 +5665,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6503,25 +5763,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6576,19 +5838,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -6652,19 +5902,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6762,25 +6000,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6835,19 +6075,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6911,19 +6139,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -7024,25 +6240,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7097,19 +6315,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7174,19 +6380,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -7288,25 +6482,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7361,19 +6557,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7438,19 +6622,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -7553,25 +6725,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7626,19 +6800,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7703,19 +6865,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -7818,25 +6968,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7891,19 +7043,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7968,19 +7108,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -8084,25 +7212,27 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
+      |          def checkResult: Unit = 
+      |            if $result.!=(null) then
+      |              $result.fold[Unit](
+      |                {
+      |                  def $anonfun(x$0: Throwable): Nothing = throw x$0
+      |                  closure($anonfun)
+      |                }
+      |              , 
+      |                {
+      |                  def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                  closure($anonfun)
+      |                }
+      |              )
+      |             else ()
       |          $continuation.asInstanceOf[
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |          ].$label match
       |            {
       |              case 0 =>
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -8157,19 +7287,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -8233,19 +7351,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                if $result.!=(null) then
-      |                  $result.fold[Unit](
-      |                    {
-      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
-      |                      closure($anonfun)
-      |                    }
-      |                  ,
-      |                    {
-      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
-      |                      closure($anonfun)
-      |                    }
-      |                  )
-      |                 else ()
+      |                checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -73,7 +73,7 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def checkResult: Unit = 
+       |              def $checkResult: Unit = 
        |                if $result.!=(null) then 
        |                  $result.fold[Unit](
        |                    {
@@ -90,7 +90,7 @@ trait StateMachineFixtures {
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    checkResult
+       |                    $checkResult
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -102,7 +102,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 1 => 
-       |                    checkResult
+       |                    $checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -164,7 +164,7 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def checkResult: Unit = 
+       |              def $checkResult: Unit = 
        |                if $result.!=(null) then 
        |                  $result.fold[Unit](
        |                    {
@@ -181,7 +181,7 @@ trait StateMachineFixtures {
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    checkResult
+       |                    $checkResult
        |                    $continuation.asInstanceOf[program$foo$1].I$0 = x##1
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -195,7 +195,7 @@ trait StateMachineFixtures {
        |                    ()
        |                  case 1 => 
        |                    x##1 = $continuation.asInstanceOf[program$foo$1].I$0
-       |                    checkResult
+       |                    $checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -254,7 +254,7 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def checkResult: Unit = 
+       |              def $checkResult: Unit = 
        |                if $result.!=(null) then 
        |                  $result.fold[Unit](
        |                    {
@@ -271,7 +271,7 @@ trait StateMachineFixtures {
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    checkResult
+       |                    $checkResult
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -284,7 +284,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    checkResult
+       |                    $checkResult
        |                    label1[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
@@ -298,7 +298,7 @@ trait StateMachineFixtures {
        |                    return[label2] ()
        |                    ()
        |                  case 2 => 
-       |                    checkResult
+       |                    $checkResult
        |                    label2[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
@@ -311,7 +311,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 3 => 
-       |                    checkResult
+       |                    $checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -370,7 +370,7 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def checkResult: Unit = 
+       |              def $checkResult: Unit = 
        |                if $result.!=(null) then 
        |                  $result.fold[Unit](
        |                    {
@@ -387,7 +387,7 @@ trait StateMachineFixtures {
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    checkResult
+       |                    $checkResult
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
@@ -402,7 +402,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    checkResult
+       |                    $checkResult
        |                    label1[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
@@ -417,7 +417,7 @@ trait StateMachineFixtures {
        |                    return[label2] ()
        |                    ()
        |                  case 2 => 
-       |                    checkResult
+       |                    $checkResult
        |                    label2[Unit]: <empty>
        |                    $continuation.asInstanceOf[program$foo$1].$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
@@ -432,7 +432,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 3 => 
-       |                    checkResult
+       |                    $checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -491,7 +491,7 @@ trait StateMachineFixtures {
        |                }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |                $continuation.asInstanceOf[program$foo$1].$result
-       |              def checkResult: Unit = 
+       |              def $checkResult: Unit = 
        |                if $result.!=(null) then 
        |                  $result.fold[Unit](
        |                    {
@@ -508,7 +508,7 @@ trait StateMachineFixtures {
        |              $continuation.asInstanceOf[program$foo$1].$label match 
        |                {
        |                  case 0 => 
-       |                    checkResult
+       |                    $checkResult
        |                    println("Start")
        |                    $continuation.asInstanceOf[program$foo$1].$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -522,7 +522,7 @@ trait StateMachineFixtures {
        |                    return[label1] ()
        |                    ()
        |                  case 1 => 
-       |                    checkResult
+       |                    $checkResult
        |                    label1[Unit]: <empty>
        |                    val x: String = "World"
        |                    println("Hello")
@@ -538,7 +538,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 2 => 
-       |                    checkResult
+       |                    $checkResult
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |                }
@@ -597,7 +597,7 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
-       |            def checkResult: Unit = 
+       |            def $checkResult: Unit = 
        |              if $result.!=(null) then 
        |                $result.fold[Unit](
        |                  {
@@ -614,7 +614,7 @@ trait StateMachineFixtures {
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  checkResult
+       |                  $checkResult
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -627,7 +627,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  checkResult
+       |                  $checkResult
        |                  label1[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
@@ -641,7 +641,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  checkResult
+       |                  $checkResult
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -654,7 +654,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  checkResult
+       |                  $checkResult
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -710,7 +710,7 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
-       |            def checkResult: Unit = 
+       |            def $checkResult: Unit = 
        |              if $result.!=(null) then 
        |                $result.fold[Unit](
        |                  {
@@ -727,7 +727,7 @@ trait StateMachineFixtures {
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  checkResult
+       |                  $checkResult
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -741,7 +741,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  checkResult
+       |                  $checkResult
        |                  label1[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
@@ -756,7 +756,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  checkResult
+       |                  $checkResult
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -769,7 +769,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  checkResult
+       |                  $checkResult
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -825,7 +825,7 @@ trait StateMachineFixtures {
        |              }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
        |              $continuation.asInstanceOf[program$foo$1].$result
-       |            def checkResult: Unit = 
+       |            def $checkResult: Unit = 
        |              if $result.!=(null) then 
        |                $result.fold[Unit](
        |                  {
@@ -842,7 +842,7 @@ trait StateMachineFixtures {
        |            $continuation.asInstanceOf[program$foo$1].$label match 
        |              {
        |                case 0 => 
-       |                  checkResult
+       |                  $checkResult
        |                  println("Start")
        |                  val x: Int = 1
        |                  $continuation.asInstanceOf[program$foo$1].$label = 1
@@ -857,7 +857,7 @@ trait StateMachineFixtures {
        |                  return[label1] ()
        |                  ()
        |                case 1 => 
-       |                  checkResult
+       |                  $checkResult
        |                  label1[Unit]: <empty>
        |                  println("Hello")
        |                  $continuation.asInstanceOf[program$foo$1].$label = 2
@@ -872,7 +872,7 @@ trait StateMachineFixtures {
        |                  return[label2] ()
        |                  ()
        |                case 2 => 
-       |                  checkResult
+       |                  $checkResult
        |                  label2[Unit]: <empty>
        |                  $continuation.asInstanceOf[program$foo$1].$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
@@ -885,7 +885,7 @@ trait StateMachineFixtures {
        |                  if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                  orThrow
        |                case 3 => 
-       |                  checkResult
+       |                  $checkResult
        |                  $result
        |                case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |              }
@@ -973,7 +973,7 @@ trait StateMachineFixtures {
        |              continuations.compileFromString$package.
        |                compileFromString$package$foo$1
        |            ].$result
-       |          def checkResult: Unit = 
+       |          def $checkResult: Unit = 
        |            if $result.!=(null) then
        |              $result.fold[Unit](
        |                {
@@ -993,7 +993,7 @@ trait StateMachineFixtures {
        |          ].$label match
        |            {
        |              case 0 =>
-       |                checkResult
+       |                $checkResult
        |                $continuation.asInstanceOf[
        |                  continuations.compileFromString$package.
        |                    compileFromString$package$foo$1
@@ -1018,7 +1018,7 @@ trait StateMachineFixtures {
        |                    continuations.compileFromString$package.
        |                      compileFromString$package$foo$1
        |                  ].I$0
-       |                checkResult
+       |                $checkResult
        |                y = $result.asInstanceOf[Int]
        |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
        |            }
@@ -1103,7 +1103,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$foo$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -1123,7 +1123,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$foo$1
@@ -1147,7 +1147,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  ].I$0
-      |                checkResult
+      |                $checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1232,7 +1232,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$foo$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -1252,7 +1252,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                xx = 111
       |                println(xx)
       |                $continuation.asInstanceOf[
@@ -1278,7 +1278,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  ].I$0
-      |                checkResult
+      |                $checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1383,7 +1383,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -1403,7 +1403,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                pp = 11
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1439,7 +1439,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
@@ -1496,7 +1496,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                yy = $result.asInstanceOf[String]
       |                label2[Unit]: <empty>
       |                tt = 100
@@ -1569,7 +1569,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$5
-      |                checkResult
+      |                $checkResult
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1672,7 +1672,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -1692,7 +1692,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                pp = 11
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1728,7 +1728,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
@@ -1784,7 +1784,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                label2[Unit]: <empty>
       |                tt = 100
       |                $continuation.asInstanceOf[
@@ -1847,7 +1847,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -1938,7 +1938,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -1958,7 +1958,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                println("Hello")
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -1992,7 +1992,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                checkResult
+      |                $checkResult
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val z: Int = 1
@@ -2037,7 +2037,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2123,7 +2123,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -2143,7 +2143,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2160,7 +2160,7 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                checkResult
+      |                $checkResult
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -2186,7 +2186,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2281,7 +2281,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -2301,7 +2301,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                println("Hello")
       |                val z: Int = 100
       |                $continuation.asInstanceOf[
@@ -2329,7 +2329,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                checkResult
+      |                $checkResult
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                j = 9
@@ -2376,7 +2376,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                w = $result.asInstanceOf[Int]
       |                label2[Unit]: <empty>
       |                println("World")
@@ -2430,7 +2430,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2520,7 +2520,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -2540,7 +2540,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2566,7 +2566,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$0
-      |                checkResult
+      |                $checkResult
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -2601,7 +2601,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2699,7 +2699,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -2719,7 +2719,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                q = 2
       |                val w: Int = 3
       |                $continuation.asInstanceOf[
@@ -2756,7 +2756,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                p = 1
@@ -2812,7 +2812,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -2905,7 +2905,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -2925,7 +2925,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -2960,7 +2960,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3004,7 +3004,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3121,7 +3121,7 @@ trait StateMachineFixtures {
       |                }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
       |                $continuation.asInstanceOf[program$fooTest$1].$result
-      |              def checkResult: Unit = 
+      |              def $checkResult: Unit = 
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
@@ -3138,7 +3138,7 @@ trait StateMachineFixtures {
       |              $continuation.asInstanceOf[program$fooTest$1].$label match
       |                {
       |                  case 0 =>
-      |                    checkResult
+      |                    $checkResult
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
       |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
       |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
@@ -3156,7 +3156,7 @@ trait StateMachineFixtures {
       |                  case 1 =>
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    checkResult
+      |                    $checkResult
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
@@ -3183,7 +3183,7 @@ trait StateMachineFixtures {
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
       |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
-      |                    checkResult
+      |                    $checkResult
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |                }
@@ -3352,7 +3352,7 @@ trait StateMachineFixtures {
       |                }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
       |                $continuation.asInstanceOf[program$fooTest$1].$result
-      |              def checkResult: Unit = 
+      |              def $checkResult: Unit = 
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
@@ -3369,7 +3369,7 @@ trait StateMachineFixtures {
       |              $continuation.asInstanceOf[program$fooTest$1].$label match
       |                {
       |                  case 0 =>
-      |                    checkResult
+      |                    $checkResult
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
       |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
       |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
@@ -3387,7 +3387,7 @@ trait StateMachineFixtures {
       |                  case 1 =>
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    checkResult
+      |                    $checkResult
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
       |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
@@ -3414,7 +3414,7 @@ trait StateMachineFixtures {
       |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
       |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
       |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
-      |                    checkResult
+      |                    $checkResult
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |                }
@@ -3513,7 +3513,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -3533,7 +3533,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3577,7 +3577,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3630,7 +3630,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3724,7 +3724,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -3744,7 +3744,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3779,7 +3779,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -3823,7 +3823,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -3915,7 +3915,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -3935,7 +3935,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
       |                    compileFromString$package$fooTest$1
@@ -3970,7 +3970,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4014,7 +4014,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4106,7 +4106,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -4126,7 +4126,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                println("Hello")
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -4162,7 +4162,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4206,7 +4206,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4298,7 +4298,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -4318,7 +4318,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
       |                  continuations.compileFromString$package.
@@ -4354,7 +4354,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4398,7 +4398,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4490,7 +4490,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -4510,7 +4510,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                println("Hello")
       |                println("World")
       |                $continuation.asInstanceOf[
@@ -4547,7 +4547,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4591,7 +4591,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4683,7 +4683,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -4703,7 +4703,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                println("Hello")
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -4740,7 +4740,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$1
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4784,7 +4784,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -4879,7 +4879,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -4899,7 +4899,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -4945,7 +4945,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                $continuation.asInstanceOf[
@@ -4998,7 +4998,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5093,7 +5093,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -5113,7 +5113,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                val w: Int = 1
       |                $continuation.asInstanceOf[
@@ -5159,7 +5159,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5213,7 +5213,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5311,7 +5311,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -5331,7 +5331,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -5386,7 +5386,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(1)
@@ -5449,7 +5449,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5544,7 +5544,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -5564,7 +5564,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                val a: Int = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -5610,7 +5610,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$2
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5665,7 +5665,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -5763,7 +5763,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -5783,7 +5783,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -5838,7 +5838,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
@@ -5902,7 +5902,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6000,7 +6000,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -6020,7 +6020,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6075,7 +6075,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6139,7 +6139,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6240,7 +6240,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -6260,7 +6260,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6315,7 +6315,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6380,7 +6380,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6482,7 +6482,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -6502,7 +6502,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6557,7 +6557,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6622,7 +6622,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6725,7 +6725,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -6745,7 +6745,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -6800,7 +6800,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -6865,7 +6865,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -6968,7 +6968,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -6988,7 +6988,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7043,7 +7043,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7108,7 +7108,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }
@@ -7212,7 +7212,7 @@ trait StateMachineFixtures {
       |              continuations.compileFromString$package.
       |                compileFromString$package$fooTest$1
       |            ].$result
-      |          def checkResult: Unit = 
+      |          def $checkResult: Unit = 
       |            if $result.!=(null) then
       |              $result.fold[Unit](
       |                {
@@ -7232,7 +7232,7 @@ trait StateMachineFixtures {
       |          ].$label match
       |            {
       |              case 0 =>
-      |                checkResult
+      |                $checkResult
       |                a = 1
       |                b = 1
       |                $continuation.asInstanceOf[
@@ -7287,7 +7287,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$3
-      |                checkResult
+      |                $checkResult
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
@@ -7351,7 +7351,7 @@ trait StateMachineFixtures {
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  ].I$4
-      |                checkResult
+      |                $checkResult
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
       |            }


### PR DESCRIPTION
This reduces the size of the generated code.

_Note_ still fixing tests at time of opening PR.