### PR TITLE
cu-862javy8t: Creates ForceableCompilationPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # scala-fx
 
+## BUILD NOTICE
+
+The following projects have been unaggregated and must be compiled seperately and run with runMain:
+
+* continuationsPluginExample
+* zero-arguments-no-continuation-treeview
+* zero-arguments-one-continuation-code-before-used-after
+* list-map
+* two-arguments-two-continuations
+
+To run these projects, you must use `runMain` with the fully qualified name of the main.
+
+```shell
+$ sbt
+root> continuationsPluginExample/runMain examples.ThreeDependentcontinuations
+```
+
+This is so that ci build will continue to work until
+https://github.com/sbt/zinc/pull/1174 is merged and resolved.
+
 ## Getting started
 
 Scala-fx is an effects library for Scala 3 that introduces structured concurrency and an abilities system to describe pure functions and programs. 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / versionScheme := Some("early-semver")
 addCommandAlias(
   "plugin-example",
   "reload; clean; publishLocal; continuationsPluginExample/compile")
-addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; github; mdoc; test")
+addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; github; mdoc; root / test")
 addCommandAlias("ci-docs", "github; mdoc")
 addCommandAlias("ci-publish", "github; ci-release")
 
@@ -18,7 +18,7 @@ lazy val root = // I
   (project in file("./")).aggregate(
     benchmarks, // A
     continuationsPlugin, // C
-    continuationsPluginExample, // D
+    // continuationsPluginExample, // D
     documentation, // E
     `http-scala-fx`, // F
     `java-net-multipart-body-publisher`, // G
@@ -26,10 +26,10 @@ lazy val root = // I
     `scala-fx`, // J
     `scalike-jdbc-scala-fx`, // K
     `sttp-scala-fx`, // L
-    `zero-arguments-no-continuation-treeview`,
-    `zero-arguments-one-continuation-code-before-used-after`,
-    `list-map`,
-    `two-arguments-two-continuations`,
+    // `zero-arguments-no-continuation-treeview`,
+    // `zero-arguments-one-continuation-code-before-used-after`,
+    // `list-map`,
+    // `two-arguments-two-continuations`,
     `munit-snap`
   )
 
@@ -47,25 +47,30 @@ lazy val continuationsPluginExample = project
   .settings(
     continuationsPluginExampleSettings: _*
   )
+  .enablePlugins(ForceableCompilationPlugin)
 
 lazy val `zero-arguments-no-continuation-treeview` =
   (project in file("./zero-arguments-no-continuation-treeview"))
     .settings(continuationsPluginExampleShowTreeSettings: _*)
     .dependsOn(continuationsPlugin)
+    .enablePlugins(ForceableCompilationPlugin)
 
 lazy val `zero-arguments-one-continuation-code-before-used-after` =
   (project in file("./zero-arguments-one-continuation-code-before-used-after"))
     .settings(continuationsPluginExampleShowTreeSettings: _*)
     .dependsOn(continuationsPlugin)
+    .enablePlugins(ForceableCompilationPlugin)
 
 lazy val `list-map` = (project in file("./list-map"))
   .settings(continuationsPluginExampleShowTreeSettings: _*)
   .dependsOn(continuationsPlugin)
+  .enablePlugins(ForceableCompilationPlugin)
 
 lazy val `two-arguments-two-continuations` =
   (project in file("./two-arguments-two-continuations"))
     .settings(continuationsPluginExampleShowTreeSettings: _*)
     .dependsOn(continuationsPlugin)
+    .enablePlugins(ForceableCompilationPlugin)
 
 lazy val benchmarks =
   project.dependsOn(`scala-fx`).settings(publish / skip := true).enablePlugins(JmhPlugin)
@@ -184,6 +189,7 @@ lazy val continuationsPluginExampleShowTreeSettings: Seq[Def.Setting[_]] =
     publish / skip := true,
     autoCompilerPlugins := true,
     resolvers += Resolver.mavenLocal,
+    forceCompilation := true,
     Compile / scalacOptions += s"-Xplugin:${(continuationsPlugin / Compile / packageBin).value}",
     Compile / scalacOptions += "-Xprint:continuations",
     Test / scalacOptions += s"-Xplugin: ${(continuationsPlugin / Compile / packageBin).value}",
@@ -194,9 +200,10 @@ lazy val continuationsPluginExampleSettings: Seq[Def.Setting[_]] =
   Seq(
     publish / skip := true,
     autoCompilerPlugins := true,
+    forceCompilation := true,
     resolvers += Resolver.mavenLocal,
     Compile / scalacOptions += s"-Xplugin:${(continuationsPlugin / Compile / packageBin).value}",
-    Test / scalacOptions += s"-Xplugin: ${(continuationsPlugin / Compile / packageBin).value}"
+    Test / scalacOptions += s"-Xplugin:${(continuationsPlugin / Compile / packageBin).value}"
   )
 
 lazy val munitScalaFXSettings = Defaults.itSettings ++ Seq(

--- a/project/src/main/scala/fx/ForceableCompilationPlugin.scala
+++ b/project/src/main/scala/fx/ForceableCompilationPlugin.scala
@@ -1,0 +1,199 @@
+package fx
+
+import sbt._
+import sbt.util.CacheImplicits._
+import sbt.Keys._
+
+import xsbti.compile.{CompileOrder => CO, _}
+import scala.sys.process._
+import scala.collection.JavaConverters._
+
+object ForceableCompilationPlugin extends AutoPlugin {
+  object autoImport {
+    lazy val forceCompilation =
+      settingKey[Boolean]("Forces a full compilation. Default is false.")
+    lazy val isx8664 = taskKey[Boolean]("Checks to see if the processor is x86-64.")
+    lazy val installCoursier = taskKey[Unit]("Install coursier if needed")
+    lazy val hasCoursier = taskKey[Boolean]("Checks to see if coursier is installed")
+    lazy val hasHomebrew = taskKey[Boolean]("Checks to see if homebrew is installed")
+
+  }
+
+  private def which(programName: String): Int = s"which $programName".!
+
+  private def hc(): Boolean = isZero(which("cs"))
+
+  private def hb(): Boolean = isZero(which("brew"))
+
+  private def isZero(actualStatus: Int): Boolean = actualStatus == 0
+
+  private def _isX8664(): Boolean = "uname -a".lineStream.mkString.contains("x86_64")
+
+  private def installCoursierX86() = {
+    if (!isZero(
+        ("curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" #| "gzip -d" #> "cs" #&& "chmod +x cs" #&& "./cs setup").!)) {
+      throw new IllegalStateException(
+        "Installing coursier failed. Please run `curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup` to install coursier.")
+    } else ()
+  }
+  private def installCoursierArm() = {
+    if (!isZero(
+        "curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz" #| "gzip -d" #> "cs" #&& "chmod +x cs" #&& "./cs setup" !)) {
+      throw new IllegalStateException(
+        "Installing coursier failed. Please run `curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup` to install coursier.")
+    } else ()
+  }
+  private def installCoursierWithHomebrew() =
+    if (!isZero("brew install coursier/formulas/coursier" #&& "cs setup" !)) {
+      throw new IllegalStateException(
+        "Installing coursier failed. If you have an M1 or M2, please run `curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup` to install coursier. Otherwise run `brew install coursier/formulas/coursier && cs setup`.")
+    } else ()
+
+  import autoImport._
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    hasCoursier := hasCoursier.previous.getOrElse(hc()),
+    hasHomebrew := hasHomebrew.previous.getOrElse(hb()),
+    isx8664 := isx8664.previous.getOrElse(_isX8664()),
+    installCoursier := {
+      val hcv = hasCoursier.value
+      val hhbv = hasHomebrew.value
+      val ix8664v = isx8664.value
+      if (!hcv && hhbv) {
+        installCoursierWithHomebrew()
+      } else if (!hcv && ix8664v) {
+        installCoursierX86()
+      } else if (!hcv && !ix8664v) {
+        installCoursierArm()
+      } else ()
+    },
+    Test / forceCompilation := false,
+    Compile / forceCompilation := false,
+    Compile / compileIncremental := {
+      if (forceCompilation.value) {
+
+        val log = streams.value.log
+
+        val _ = installCoursier.value
+
+        val classesDir = (Compile / classDirectory).value.getAbsolutePath
+
+        sbt.io.IO.createDirectories(Seq(new java.io.File(classesDir)))
+
+        log.info(s"Compile scalacOptions: ${(Compile / scalacOptions).value}")
+
+        val compileSources = (Compile / sources).value.map(_.getAbsolutePath)
+
+        // format: off
+        val compileCommand =
+          s"cs launch scalac:${(Compile / scalaVersion).value} -- ${(Compile / scalacOptions).value.mkString(" ")} -classpath ${(Compile / dependencyClasspath).value.map(_.data.getAbsolutePath).mkString(":")} -d ${(Compile / classDirectory).value.getAbsolutePath} ${compileSources.mkString(" ")}"
+        // format: on
+        log.info(s"compile command: $compileCommand")
+
+        val compilerMessages = compileCommand.lineStream.mkString
+
+        log.info(compilerMessages)
+
+        xsbti
+          .compile
+          .CompileResult
+          .of(
+            sbt.internal.inc.Analysis.empty,
+            xsbti
+              .compile
+              .MiniSetup
+              .of(
+                new MultipleOutput {
+                  override def getOutputGroups: Array[OutputGroup] = Array.empty[OutputGroup]
+                },
+                xsbti
+                  .compile
+                  .MiniOptions
+                  .of(
+                    Array.empty[FileHash],
+                    (Compile / scalacOptions).value.toArray,
+                    (compile / javacOptions).value.toArray),
+                (Compile / scalaVersion).value,
+                CompileOrder.Mixed,
+                false,
+                Array.empty[xsbti.T2[String, String]]
+              ),
+            true
+          )
+      } else (Compile / compileIncremental).value
+    },
+    Test / compileIncremental := {
+      if (forceCompilation.value) {
+
+        val log = streams.value.log
+
+        val _ = installCoursier.value
+
+        val classesDir = (Test / classDirectory).value.getAbsolutePath
+
+        sbt.io.IO.createDirectories(Seq(new java.io.File(classesDir)))
+
+        log.info(s"Test scalacOptions: ${(Test / scalacOptions).value}")
+
+        val compileSources = (Test / sources).value.map(_.getAbsolutePath)
+
+        // format: off
+        val compileCommand =
+          s"cs launch scalac:${(Test / scalaVersion).value} -- ${(Test / scalacOptions).value.mkString(" ")} -classpath ${(Test / dependencyClasspath).value.map(_.data.getAbsolutePath).mkString(":")} -d ${(Test / classDirectory).value.getAbsolutePath} ${compileSources.mkString(" ")}"
+        // format: on
+        log.info(s"compile command: $compileCommand")
+
+        val compilerMessages = compileCommand.lineStream.mkString
+
+        log.info(compilerMessages)
+
+        xsbti
+          .compile
+          .CompileResult
+          .of(
+            sbt.internal.inc.Analysis.empty,
+            xsbti
+              .compile
+              .MiniSetup
+              .of(
+                new MultipleOutput {
+                  override def getOutputGroups: Array[OutputGroup] = Array.empty[OutputGroup]
+                },
+                xsbti
+                  .compile
+                  .MiniOptions
+                  .of(
+                    Array.empty[FileHash],
+                    (Test / scalacOptions).value.toArray,
+                    (compile / javacOptions).value.toArray),
+                (Test / scalaVersion).value,
+                CompileOrder.Mixed,
+                false,
+                Array.empty[xsbti.T2[String, String]]
+              ),
+            true
+          )
+      } else (Test / compileIncremental).value
+    },
+    Test / previousCompile := {
+      if (forceCompilation.value) {
+        xsbti
+          .compile
+          .PreviousResult
+          .of(
+            java.util.Optional.empty[xsbti.compile.CompileAnalysis](),
+            java.util.Optional.empty[xsbti.compile.MiniSetup]())
+      } else (Test / previousCompile).value
+    },
+    Compile / previousCompile := {
+      if (forceCompilation.value) {
+        xsbti
+          .compile
+          .PreviousResult
+          .of(
+            java.util.Optional.empty[xsbti.compile.CompileAnalysis](),
+            java.util.Optional.empty[xsbti.compile.MiniSetup]())
+      } else (Compile / previousCompile).value
+    }
+  )
+}


### PR DESCRIPTION
The plugin allows you to force compilation with scalac.

It has some limitations.

1. You must have the same version of scala and scalac on your path as is used in the build.sbt. Currently this is 3.1.2.
2. It will only compile scala files.
3. You must run your examples in projects where `ForceableCompilationPlugin` is enabled and `forceCompilation` is `true` with `<projectName> / runMain <fullyQualifiedNameOfMain>`

This is only necessary until https://github.com/sbt/sbt/issues/7157 is resolved.