### PR TITLE
Refactor: split continuation symbol out of ValDef.

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -853,7 +853,7 @@ object DefDefTransforms extends TreesChecks:
         newSymbol(
           newParent,
           termName("$continuation"),
-          Local | Mutable | Synthetic,
+          Local | Synthetic,
           continuationStateMachineClass.tpe).entered
 
       val completionMatch = {

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsChainedTwoArgs.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsChainedTwoArgs.scala
@@ -37,7 +37,6 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
           )
       }
   }
-
   compilerContextWithContinuationsPlugin.test(
     "1- it should convert into a state machine two continuations chained with one generic param"
   ) {
@@ -85,7 +84,7 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
           |      val z = s.suspendContinuation[A] { _.resume(Right { a }) }
           |      s.suspendContinuation[B] { _.resume(Right { println(z); b }) }
           |  }
-          |  
+          |
           |  fooTest(Foo(1), Bar(2))
           |}
           |""".stripMargin

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -63,7 +63,7 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: program$foo$1 = 
+       |              val $continuation: program$foo$1 = 
        |                completion match 
        |                  {
        |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -140,7 +140,7 @@ trait StateMachineFixtures {
        |          {
        |            var x##1: Int = x
        |            {
-       |              var $continuation: program$foo$1 = 
+       |              val $continuation: program$foo$1 = 
        |                completion match 
        |                  {
        |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -216,7 +216,7 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: program$foo$1 = 
+       |              val $continuation: program$foo$1 = 
        |                completion match 
        |                  {
        |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -318,7 +318,7 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: program$foo$1 = 
+       |              val $continuation: program$foo$1 = 
        |                completion match 
        |                  {
        |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -425,7 +425,7 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: program$foo$1 = 
+       |              val $continuation: program$foo$1 = 
        |                completion match 
        |                  {
        |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -517,7 +517,7 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            var $continuation: program$foo$1 = 
+       |            val $continuation: program$foo$1 = 
        |              completion match 
        |                {
        |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -616,7 +616,7 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            var $continuation: program$foo$1 = 
+       |            val $continuation: program$foo$1 = 
        |              completion match 
        |                {
        |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -717,7 +717,7 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            var $continuation: program$foo$1 = 
+       |            val $continuation: program$foo$1 = 
        |              completion match 
        |                {
        |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
@@ -822,7 +822,7 @@ trait StateMachineFixtures {
        |        var x##1: Int = x
        |        var y: Int = null
        |        {
-       |          var $continuation:
+       |          val $continuation:
        |            continuations.compileFromString$package.
        |              compileFromString$package$foo$1
        |           =
@@ -920,7 +920,7 @@ trait StateMachineFixtures {
       |      {
       |        var qq##1: Int = qq
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$foo$1
       |           =
@@ -1017,7 +1017,7 @@ trait StateMachineFixtures {
       |      {
       |        var xx: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$foo$1
       |           =
@@ -1136,7 +1136,7 @@ trait StateMachineFixtures {
       |        var tt: Int = null
       |        var zz: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -1310,7 +1310,7 @@ trait StateMachineFixtures {
       |        var tt: Int = null
       |        var zz: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -1468,7 +1468,7 @@ trait StateMachineFixtures {
       |        var x##1: Int = x
       |        var y: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -1604,7 +1604,7 @@ trait StateMachineFixtures {
       |      {
       |        var x: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -1727,7 +1727,7 @@ trait StateMachineFixtures {
       |        var j: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -1879,7 +1879,7 @@ trait StateMachineFixtures {
       |        var x##1: Int = x
       |        var y: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -2009,7 +2009,7 @@ trait StateMachineFixtures {
       |        var p: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -2145,7 +2145,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: 
+      |          val $continuation: 
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -2325,7 +2325,7 @@ trait StateMachineFixtures {
       |            var b##1: Int = b
       |            var z: A = null
       |            {
-      |              var $continuation: program$fooTest$1 = 
+      |              val $continuation: program$fooTest$1 = 
       |                completion match
       |                  {
       |                    case x$0 @ <empty> if
@@ -2542,7 +2542,7 @@ trait StateMachineFixtures {
       |            var b##1: B = b
       |            var z: A = null
       |            {
-      |              var $continuation: program$fooTest$1 =
+      |              val $continuation: program$fooTest$1 =
       |                completion match
       |                  {
       |                    case x$0 @ <empty> if
@@ -2662,7 +2662,7 @@ trait StateMachineFixtures {
       |        var ec##1: concurrent.ExecutionContext = ec
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -2796,7 +2796,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -2924,7 +2924,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3052,7 +3052,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3181,7 +3181,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3310,7 +3310,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3440,7 +3440,7 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3573,7 +3573,7 @@ trait StateMachineFixtures {
       |        var a: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3710,7 +3710,7 @@ trait StateMachineFixtures {
       |        var a: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3851,7 +3851,7 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -3993,7 +3993,7 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -4135,7 +4135,7 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -4281,7 +4281,7 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -4430,7 +4430,7 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -4581,7 +4581,7 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -4733,7 +4733,7 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -4885,7 +4885,7 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =
@@ -5038,7 +5038,7 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation:
+      |          val $continuation:
       |            continuations.compileFromString$package.
       |              compileFromString$package$fooTest$1
       |           =

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -63,21 +63,21 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
+       |              var $continuation: program$foo$1 = 
+       |                completion match 
+       |                  {
+       |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                      x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                      x$0
+       |                    case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                  }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                $continuation.$result
+       |              $continuation.$label match 
        |                {
        |                  case 0 => 
        |                    continuations.Continuation.checkResult($result)
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    $continuation.$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                        continuations.Continuation.State.Undecided
@@ -140,22 +140,22 @@ trait StateMachineFixtures {
        |          {
        |            var x##1: Int = x
        |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
+       |              var $continuation: program$foo$1 = 
+       |                completion match 
+       |                  {
+       |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                      x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                      x$0
+       |                    case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                  }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                $continuation.$result
+       |              $continuation.$label match 
        |                {
        |                  case 0 => 
        |                    continuations.Continuation.checkResult($result)
-       |                    $continuation.asInstanceOf[program$foo$1].I$0 = x##1
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    $continuation.I$0 = x##1
+       |                    $continuation.$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                        continuations.Continuation.State.Undecided
@@ -166,7 +166,7 @@ trait StateMachineFixtures {
        |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
        |                    ()
        |                  case 1 => 
-       |                    x##1 = $continuation.asInstanceOf[program$foo$1].I$0
+       |                    x##1 = $continuation.I$0
        |                    continuations.Continuation.checkResult($result)
        |                    ()
        |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -216,21 +216,21 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
+       |              var $continuation: program$foo$1 = 
+       |                completion match 
+       |                  {
+       |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                      x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                      x$0
+       |                    case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                  }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                $continuation.$result
+       |              $continuation.$label match 
        |                {
        |                  case 0 => 
        |                    continuations.Continuation.checkResult($result)
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    $continuation.$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                        continuations.Continuation.State.Undecided
@@ -244,7 +244,7 @@ trait StateMachineFixtures {
        |                  case 1 => 
        |                    continuations.Continuation.checkResult($result)
        |                    label1[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    $continuation.$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                      new continuations.SafeContinuation[Boolean](
        |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -258,7 +258,7 @@ trait StateMachineFixtures {
        |                  case 2 => 
        |                    continuations.Continuation.checkResult($result)
        |                    label2[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    $continuation.$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
        |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
        |                        , 
@@ -318,21 +318,21 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
+       |              var $continuation: program$foo$1 = 
+       |                completion match 
+       |                  {
+       |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                      x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                      x$0
+       |                    case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                  }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                $continuation.$result
+       |              $continuation.$label match 
        |                {
        |                  case 0 => 
        |                    continuations.Continuation.checkResult($result)
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    $continuation.$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                        continuations.Continuation.State.Undecided
@@ -348,7 +348,7 @@ trait StateMachineFixtures {
        |                  case 1 => 
        |                    continuations.Continuation.checkResult($result)
        |                    label1[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    $continuation.$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                      new continuations.SafeContinuation[Boolean](
        |                        continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
@@ -363,7 +363,7 @@ trait StateMachineFixtures {
        |                  case 2 => 
        |                    continuations.Continuation.checkResult($result)
        |                    label2[Unit]: <empty>
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                    $continuation.$label = 3
        |                    val safeContinuation: continuations.SafeContinuation[String] = 
        |                      new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)()
        |                        , 
@@ -425,22 +425,22 @@ trait StateMachineFixtures {
        |         = 
        |          {
        |            {
-       |              var $continuation: continuations.Continuation[Any] | Null = null
-       |              completion match 
-       |                {
-       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                    $continuation = x$0
-       |                    $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                  case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |                }
+       |              var $continuation: program$foo$1 = 
+       |                completion match 
+       |                  {
+       |                    case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                      x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                      x$0
+       |                    case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                  }
        |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |                $continuation.asInstanceOf[program$foo$1].$result
-       |              $continuation.asInstanceOf[program$foo$1].$label match 
+       |                $continuation.$result
+       |              $continuation.$label match 
        |                {
        |                  case 0 => 
        |                    continuations.Continuation.checkResult($result)
        |                    println("Start")
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                    $continuation.$label = 1
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                        continuations.Continuation.State.Undecided
@@ -457,7 +457,7 @@ trait StateMachineFixtures {
        |                    val x: String = "World"
        |                    println("Hello")
        |                    println(x)
-       |                    $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                    $continuation.$label = 2
        |                    val safeContinuation: continuations.SafeContinuation[Int] = 
        |                      new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                        continuations.Continuation.State.Undecided
@@ -517,21 +517,21 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            var $continuation: continuations.Continuation[Any] | Null = null
-       |            completion match 
-       |              {
-       |                case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                  $continuation = x$0
-       |                  $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |              }
+       |            var $continuation: program$foo$1 = 
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                    x$0
+       |                  case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |              $continuation.asInstanceOf[program$foo$1].$result
-       |            $continuation.asInstanceOf[program$foo$1].$label match 
+       |              $continuation.$result
+       |            $continuation.$label match 
        |              {
        |                case 0 => 
        |                  continuations.Continuation.checkResult($result)
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                  $continuation.$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
        |                      , 
@@ -545,7 +545,7 @@ trait StateMachineFixtures {
        |                case 1 => 
        |                  continuations.Continuation.checkResult($result)
        |                  label1[Unit]: <empty>
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                  $continuation.$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
        |                    new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(), 
        |                      continuations.Continuation.State.Undecided
@@ -559,7 +559,7 @@ trait StateMachineFixtures {
        |                case 2 => 
        |                  continuations.Continuation.checkResult($result)
        |                  label2[Unit]: <empty>
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                  $continuation.$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
        |                    new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                      continuations.Continuation.State.Undecided
@@ -616,21 +616,21 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            var $continuation: continuations.Continuation[Any] | Null = null
-       |            completion match 
-       |              {
-       |                case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                  $continuation = x$0
-       |                  $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |              }
+       |            var $continuation: program$foo$1 = 
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                    x$0
+       |                  case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |              $continuation.asInstanceOf[program$foo$1].$result
-       |            $continuation.asInstanceOf[program$foo$1].$label match 
+       |              $continuation.$result
+       |            $continuation.$label match 
        |              {
        |                case 0 => 
        |                  continuations.Continuation.checkResult($result)
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                  $continuation.$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
        |                      , 
@@ -645,7 +645,7 @@ trait StateMachineFixtures {
        |                case 1 => 
        |                  continuations.Continuation.checkResult($result)
        |                  label1[Unit]: <empty>
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                  $continuation.$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
        |                    new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(), 
        |                      continuations.Continuation.State.Undecided
@@ -660,7 +660,7 @@ trait StateMachineFixtures {
        |                case 2 => 
        |                  continuations.Continuation.checkResult($result)
        |                  label2[Unit]: <empty>
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                  $continuation.$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
        |                    new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                      continuations.Continuation.State.Undecided
@@ -717,23 +717,23 @@ trait StateMachineFixtures {
        |          Int | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)
        |         = 
        |          {
-       |            var $continuation: continuations.Continuation[Any] | Null = null
-       |            completion match 
-       |              {
-       |                case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
-       |                  $continuation = x$0
-       |                  $continuation.asInstanceOf[program$foo$1].$label = $continuation.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
-       |                case _ => $continuation = new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |              }
+       |            var $continuation: program$foo$1 = 
+       |              completion match 
+       |                {
+       |                  case x$0 @ <empty> if x$0.isInstanceOf[program$foo$1].&&(x$0.asInstanceOf[program$foo$1].$label.&(scala.Int.MinValue).!=(0)) => 
+       |                    x$0.asInstanceOf[program$foo$1].$label = x$0.asInstanceOf[program$foo$1].$label.-(scala.Int.MinValue)
+       |                    x$0
+       |                  case _ => new program$foo$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+       |                }
        |            val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] = 
-       |              $continuation.asInstanceOf[program$foo$1].$result
-       |            $continuation.asInstanceOf[program$foo$1].$label match 
+       |              $continuation.$result
+       |            $continuation.$label match 
        |              {
        |                case 0 => 
        |                  continuations.Continuation.checkResult($result)
        |                  println("Start")
        |                  val x: Int = 1
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 1
+       |                  $continuation.$label = 1
        |                  val safeContinuation: continuations.SafeContinuation[Boolean] = 
        |                    new continuations.SafeContinuation[Boolean](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Boolean]($continuation)()
        |                      , 
@@ -748,7 +748,7 @@ trait StateMachineFixtures {
        |                  continuations.Continuation.checkResult($result)
        |                  label1[Unit]: <empty>
        |                  println("Hello")
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 2
+       |                  $continuation.$label = 2
        |                  val safeContinuation: continuations.SafeContinuation[String] = 
        |                    new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(), 
        |                      continuations.Continuation.State.Undecided
@@ -762,7 +762,7 @@ trait StateMachineFixtures {
        |                case 2 => 
        |                  continuations.Continuation.checkResult($result)
        |                  label2[Unit]: <empty>
-       |                  $continuation.asInstanceOf[program$foo$1].$label = 3
+       |                  $continuation.$label = 3
        |                  val safeContinuation: continuations.SafeContinuation[Int] = 
        |                    new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(), 
        |                      continuations.Continuation.State.Undecided
@@ -822,56 +822,46 @@ trait StateMachineFixtures {
        |        var x##1: Int = x
        |        var y: Int = null
        |        {
-       |          var $continuation: continuations.Continuation[Any] | Null = null
-       |          completion match
-       |            {
-       |              case x$0 @ <empty> if
-       |                x$0.isInstanceOf[
-       |                  continuations.compileFromString$package.
-       |                    compileFromString$package$foo$1
-       |                ].&&(
+       |          var $continuation:
+       |            continuations.compileFromString$package.
+       |              compileFromString$package$foo$1
+       |           =
+       |            completion match
+       |              {
+       |                case x$0 @ <empty> if
+       |                  x$0.isInstanceOf[
+       |                    continuations.compileFromString$package.
+       |                      compileFromString$package$foo$1
+       |                  ].&&(
+       |                    x$0.asInstanceOf[
+       |                      continuations.compileFromString$package.
+       |                        compileFromString$package$foo$1
+       |                    ].$label.&(scala.Int.MinValue).!=(0)
+       |                  )
+       |                 =>
        |                  x$0.asInstanceOf[
        |                    continuations.compileFromString$package.
        |                      compileFromString$package$foo$1
-       |                  ].$label.&(scala.Int.MinValue).!=(0)
-       |                )
-       |               =>
-       |                $continuation = x$0
-       |                $continuation.asInstanceOf[
-       |                  continuations.compileFromString$package.
-       |                    compileFromString$package$foo$1
-       |                ].$label =
-       |                  $continuation.asInstanceOf[
-       |                    continuations.compileFromString$package.
-       |                      compileFromString$package$foo$1
-       |                  ].$label.-(scala.Int.MinValue)
-       |              case _ =>
-       |                $continuation =
+       |                  ].$label =
+       |                    x$0.asInstanceOf[
+       |                      continuations.compileFromString$package.
+       |                        compileFromString$package$foo$1
+       |                    ].$label.-(scala.Int.MinValue)
+       |                  x$0
+       |                case _ =>
        |                  new
        |                    continuations.compileFromString$package.
        |                      compileFromString$package$foo$1
        |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-       |            }
+       |              }
        |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-       |            $continuation.asInstanceOf[
-       |              continuations.compileFromString$package.
-       |                compileFromString$package$foo$1
-       |            ].$result
-       |          $continuation.asInstanceOf[
-       |            continuations.compileFromString$package.
-       |              compileFromString$package$foo$1
-       |          ].$label match
+       |            $continuation.$result
+       |          $continuation.$label match
        |            {
        |              case 0 =>
        |                continuations.Continuation.checkResult($result)
-       |                $continuation.asInstanceOf[
-       |                  continuations.compileFromString$package.
-       |                    compileFromString$package$foo$1
-       |                ].I$0 = x##1
-       |                $continuation.asInstanceOf[
-       |                  continuations.compileFromString$package.
-       |                    compileFromString$package$foo$1
-       |                ].$label = 1
+       |                $continuation.I$0 = x##1
+       |                $continuation.$label = 1
        |                val safeContinuation: continuations.SafeContinuation[Int] =
        |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
        |                    continuations.Continuation.State.Undecided
@@ -883,11 +873,7 @@ trait StateMachineFixtures {
        |                y = orThrow.asInstanceOf[Int]
        |                ()
        |              case 1 =>
-       |                x##1 =
-       |                  $continuation.asInstanceOf[
-       |                    continuations.compileFromString$package.
-       |                      compileFromString$package$foo$1
-       |                  ].I$0
+       |                x##1 = $continuation.I$0
        |                continuations.Continuation.checkResult($result)
        |                y = $result.asInstanceOf[Int]
        |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -934,56 +920,46 @@ trait StateMachineFixtures {
       |      {
       |        var qq##1: Int = qq
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$foo$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$foo$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$foo$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$foo$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$foo$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$foo$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].$label = 1
+      |                $continuation.I$0 = qq##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Unit] =
       |                  new continuations.SafeContinuation[Unit](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Unit]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -994,11 +970,7 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                ()
       |              case 1 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$foo$1
-      |                  ].I$0
+      |                qq##1 = $continuation.I$0
       |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -1045,58 +1017,48 @@ trait StateMachineFixtures {
       |      {
       |        var xx: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$foo$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$foo$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$foo$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$foo$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$foo$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$foo$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$foo$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$foo$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                xx = 111
       |                println(xx)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].I$0 = xx
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$foo$1
-      |                ].$label = 1
+      |                $continuation.I$0 = xx
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1107,11 +1069,7 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                ()
       |              case 1 =>
-      |                xx =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$foo$1
-      |                  ].I$0
+      |                xx = $continuation.I$0
       |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -1178,61 +1136,48 @@ trait StateMachineFixtures {
       |        var tt: Int = null
       |        var zz: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                pp = 11
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = pp
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = qq##1
+      |                $continuation.I$1 = pp
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1245,41 +1190,18 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                pp =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                qq##1 = $continuation.I$0
+      |                pp = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
       |                val rr: String = "AAA"
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = pp
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = xx
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = ww
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = qq##1
+      |                $continuation.I$1 = pp
+      |                $continuation.I$2 = xx
+      |                $continuation.I$3 = ww
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[String] =
       |                  new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1292,58 +1214,21 @@ trait StateMachineFixtures {
       |                return[label2] ()
       |                ()
       |              case 2 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                pp =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                xx =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                ww =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                qq##1 = $continuation.I$0
+      |                pp = $continuation.I$1
+      |                xx = $continuation.I$2
+      |                ww = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                yy = $result.asInstanceOf[String]
       |                label2[Unit]: <empty>
       |                tt = 100
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = pp
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = xx
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = ww
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = yy
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$5 = tt
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 3
+      |                $continuation.I$0 = qq##1
+      |                $continuation.I$1 = pp
+      |                $continuation.I$2 = xx
+      |                $continuation.I$3 = ww
+      |                $continuation.I$4 = yy
+      |                $continuation.I$5 = tt
+      |                $continuation.$label = 3
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1355,36 +1240,12 @@ trait StateMachineFixtures {
       |                zz = orThrow.asInstanceOf[Int]
       |                ()
       |              case 3 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                pp =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                xx =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                ww =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                yy =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
-      |                tt =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$5
+      |                qq##1 = $continuation.I$0
+      |                pp = $continuation.I$1
+      |                xx = $continuation.I$2
+      |                ww = $continuation.I$3
+      |                yy = $continuation.I$4
+      |                tt = $continuation.I$5
       |                continuations.Continuation.checkResult($result)
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -1449,61 +1310,48 @@ trait StateMachineFixtures {
       |        var tt: Int = null
       |        var zz: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                pp = 11
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = pp
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = qq##1
+      |                $continuation.I$1 = pp
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1516,41 +1364,18 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                pp =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                qq##1 = $continuation.I$0
+      |                pp = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                xx = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                ww = 13
       |                val rr: String = "AAA"
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = pp
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = xx
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = ww
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = qq##1
+      |                $continuation.I$1 = pp
+      |                $continuation.I$2 = xx
+      |                $continuation.I$3 = ww
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[String] =
       |                  new continuations.SafeContinuation[String](continuations.intrinsics.IntrinsicsJvm$package.intercepted[String]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1562,53 +1387,19 @@ trait StateMachineFixtures {
       |                return[label2] ()
       |                ()
       |              case 2 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                pp =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                xx =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                ww =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                qq##1 = $continuation.I$0
+      |                pp = $continuation.I$1
+      |                xx = $continuation.I$2
+      |                ww = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                label2[Unit]: <empty>
       |                tt = 100
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = qq##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = pp
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = xx
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = ww
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = tt
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 3
+      |                $continuation.I$0 = qq##1
+      |                $continuation.I$1 = pp
+      |                $continuation.I$2 = xx
+      |                $continuation.I$3 = ww
+      |                $continuation.I$4 = tt
+      |                $continuation.$label = 3
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1620,31 +1411,11 @@ trait StateMachineFixtures {
       |                zz = orThrow.asInstanceOf[Int]
       |                ()
       |              case 3 =>
-      |                qq##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                pp =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                xx =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                ww =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                tt =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                qq##1 = $continuation.I$0
+      |                pp = $continuation.I$1
+      |                xx = $continuation.I$2
+      |                ww = $continuation.I$3
+      |                tt = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                zz = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -1697,57 +1468,47 @@ trait StateMachineFixtures {
       |        var x##1: Int = x
       |        var y: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                println("Hello")
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1767,27 +1528,14 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
+      |                x##1 = $continuation.I$0
       |                continuations.Continuation.checkResult($result)
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val z: Int = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = y
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = x##1
+      |                $continuation.I$1 = y
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1807,16 +1555,8 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                ()
       |              case 2 =>
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                y =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                x##1 = $continuation.I$0
+      |                y = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -1864,52 +1604,45 @@ trait StateMachineFixtures {
       |      {
       |        var x: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1925,14 +1658,8 @@ trait StateMachineFixtures {
       |                continuations.Continuation.checkResult($result)
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = x
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -1943,11 +1670,7 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                x =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
+      |                x = $continuation.I$0
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -2004,58 +1727,48 @@ trait StateMachineFixtures {
       |        var j: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                val z: Int = 100
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = q##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = q##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2068,31 +1781,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                q##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
+      |                q##1 = $continuation.I$0
       |                continuations.Continuation.checkResult($result)
       |                x = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                j = 9
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = q##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = j
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = q##1
+      |                $continuation.I$1 = x
+      |                $continuation.I$2 = j
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2105,45 +1802,18 @@ trait StateMachineFixtures {
       |                return[label2] ()
       |                ()
       |              case 2 =>
-      |                q##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                j =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                q##1 = $continuation.I$0
+      |                x = $continuation.I$1
+      |                j = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |                label2[Unit]: <empty>
       |                println("World")
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = q##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = j
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = w
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 3
+      |                $continuation.I$0 = q##1
+      |                $continuation.I$1 = x
+      |                $continuation.I$2 = j
+      |                $continuation.I$3 = w
+      |                $continuation.$label = 3
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2154,26 +1824,10 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                ()
       |              case 3 =>
-      |                q##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                j =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                w =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                q##1 = $continuation.I$0
+      |                x = $continuation.I$1
+      |                j = $continuation.I$2
+      |                w = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -2225,56 +1879,46 @@ trait StateMachineFixtures {
       |        var x##1: Int = x
       |        var y: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2287,26 +1931,13 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
+      |                x##1 = $continuation.I$0
       |                continuations.Continuation.checkResult($result)
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = y
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = x##1
+      |                $continuation.I$1 = y
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2317,16 +1948,8 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                y =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                x##1 = $continuation.I$0
+      |                y = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -2386,62 +2009,49 @@ trait StateMachineFixtures {
       |        var p: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                q = 2
       |                val w: Int = 3
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = q
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = x##1
+      |                $continuation.I$1 = q
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2454,41 +2064,18 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                q =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                x##1 = $continuation.I$0
+      |                q = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                y = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                p = 1
       |                val t: Int = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = q
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = y
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = p
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = x##1
+      |                $continuation.I$1 = q
+      |                $continuation.I$2 = y
+      |                $continuation.I$3 = p
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2500,26 +2087,10 @@ trait StateMachineFixtures {
       |                z = orThrow.asInstanceOf[Int]
       |                ()
       |              case 2 =>
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                q =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                y =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                p =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                x##1 = $continuation.I$0
+      |                q = $continuation.I$1
+      |                y = $continuation.I$2
+      |                p = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -2574,60 +2145,47 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation: 
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2640,35 +2198,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -2679,21 +2217,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -2799,25 +2325,25 @@ trait StateMachineFixtures {
       |            var b##1: Int = b
       |            var z: A = null
       |            {
-      |              var $continuation: continuations.Continuation[Any] | Null = null
-      |              completion match
-      |                {
-      |                  case x$0 @ <empty> if
-      |                    x$0.isInstanceOf[program$fooTest$1].&&(x$0.asInstanceOf[program$fooTest$1].$label.&(scala.Int.MinValue).!=(0))
-      |                   =>
-      |                    $continuation = x$0
-      |                    $continuation.asInstanceOf[program$fooTest$1].$label = $continuation.asInstanceOf[program$fooTest$1].$label.-(scala.Int.MinValue)
-      |                  case _ => $continuation = new program$fooTest$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |                }
+      |              var $continuation: program$fooTest$1 = 
+      |                completion match
+      |                  {
+      |                    case x$0 @ <empty> if
+      |                      x$0.isInstanceOf[program$fooTest$1].&&(x$0.asInstanceOf[program$fooTest$1].$label.&(scala.Int.MinValue).!=(0))
+      |                     =>
+      |                      x$0.asInstanceOf[program$fooTest$1].$label = x$0.asInstanceOf[program$fooTest$1].$label.-(scala.Int.MinValue)
+      |                      x$0
+      |                    case _ => new program$fooTest$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |                  }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |                $continuation.asInstanceOf[program$fooTest$1].$result
-      |              $continuation.asInstanceOf[program$fooTest$1].$label match
+      |                $continuation.$result
+      |              $continuation.$label match
       |                {
       |                  case 0 =>
       |                    continuations.Continuation.checkResult($result)
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
+      |                    $continuation.I$0 = b##1
+      |                    $continuation.I$1 = a##1
+      |                    $continuation.$label = 1
       |                    val safeContinuation: continuations.SafeContinuation[A] =
       |                      new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A]($continuation)(),
       |                        continuations.Continuation.State.Undecided
@@ -2830,15 +2356,15 @@ trait StateMachineFixtures {
       |                    return[label1] ()
       |                    ()
       |                  case 1 =>
-      |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
-      |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
+      |                    b##1 = $continuation.I$0
+      |                    a##1 = $continuation.I$1
       |                    continuations.Continuation.checkResult($result)
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$2 = z
-      |                    $continuation.asInstanceOf[program$fooTest$1].$label = 2
+      |                    $continuation.I$0 = b##1
+      |                    $continuation.I$1 = a##1
+      |                    $continuation.I$2 = z
+      |                    $continuation.$label = 2
       |                    val safeContinuation: continuations.SafeContinuation[A] =
       |                      new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A]($continuation)(),
       |                        continuations.Continuation.State.Undecided
@@ -2856,9 +2382,9 @@ trait StateMachineFixtures {
       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                    orThrow
       |                  case 2 =>
-      |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
-      |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
+      |                    b##1 = $continuation.I$0
+      |                    a##1 = $continuation.I$1
+      |                    z = $continuation.I$2
       |                    continuations.Continuation.checkResult($result)
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -3016,25 +2542,25 @@ trait StateMachineFixtures {
       |            var b##1: B = b
       |            var z: A = null
       |            {
-      |              var $continuation: continuations.Continuation[Any] | Null = null
-      |              completion match
-      |                {
-      |                  case x$0 @ <empty> if
-      |                    x$0.isInstanceOf[program$fooTest$1].&&(x$0.asInstanceOf[program$fooTest$1].$label.&(scala.Int.MinValue).!=(0))
-      |                   =>
-      |                    $continuation = x$0
-      |                    $continuation.asInstanceOf[program$fooTest$1].$label = $continuation.asInstanceOf[program$fooTest$1].$label.-(scala.Int.MinValue)
-      |                  case _ => $continuation = new program$fooTest$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |                }
+      |              var $continuation: program$fooTest$1 =
+      |                completion match
+      |                  {
+      |                    case x$0 @ <empty> if
+      |                      x$0.isInstanceOf[program$fooTest$1].&&(x$0.asInstanceOf[program$fooTest$1].$label.&(scala.Int.MinValue).!=(0))
+      |                     =>
+      |                      x$0.asInstanceOf[program$fooTest$1].$label = x$0.asInstanceOf[program$fooTest$1].$label.-(scala.Int.MinValue)
+      |                      x$0
+      |                    case _ => new program$fooTest$1(completion.asInstanceOf[continuations.Continuation[Any | Null]])
+      |                  }
       |              val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |                $continuation.asInstanceOf[program$fooTest$1].$result
-      |              $continuation.asInstanceOf[program$fooTest$1].$label match
+      |                $continuation.$result
+      |              $continuation.$label match
       |                {
       |                  case 0 =>
       |                    continuations.Continuation.checkResult($result)
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].$label = 1
+      |                    $continuation.I$0 = b##1
+      |                    $continuation.I$1 = a##1
+      |                    $continuation.$label = 1
       |                    val safeContinuation: continuations.SafeContinuation[A] =
       |                      new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A]($continuation)(),
       |                        continuations.Continuation.State.Undecided
@@ -3047,15 +2573,15 @@ trait StateMachineFixtures {
       |                    return[label1] ()
       |                    ()
       |                  case 1 =>
-      |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
-      |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
+      |                    b##1 = $continuation.I$0
+      |                    a##1 = $continuation.I$1
       |                    continuations.Continuation.checkResult($result)
       |                    z = $result.asInstanceOf[A]
       |                    label1[Unit]: <empty>
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$0 = b##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$1 = a##1
-      |                    $continuation.asInstanceOf[program$fooTest$1].I$2 = z
-      |                    $continuation.asInstanceOf[program$fooTest$1].$label = 2
+      |                    $continuation.I$0 = b##1
+      |                    $continuation.I$1 = a##1
+      |                    $continuation.I$2 = z
+      |                    $continuation.$label = 2
       |                    val safeContinuation: continuations.SafeContinuation[B] =
       |                      new continuations.SafeContinuation[B](continuations.intrinsics.IntrinsicsJvm$package.intercepted[B]($continuation)(),
       |                        continuations.Continuation.State.Undecided
@@ -3073,9 +2599,9 @@ trait StateMachineFixtures {
       |                    if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                    orThrow
       |                  case 2 =>
-      |                    b##1 = $continuation.asInstanceOf[program$fooTest$1].I$0
-      |                    a##1 = $continuation.asInstanceOf[program$fooTest$1].I$1
-      |                    z = $continuation.asInstanceOf[program$fooTest$1].I$2
+      |                    b##1 = $continuation.I$0
+      |                    a##1 = $continuation.I$1
+      |                    z = $continuation.I$2
       |                    continuations.Continuation.checkResult($result)
       |                    $result
       |                  case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -3136,64 +2662,48 @@ trait StateMachineFixtures {
       |        var ec##1: concurrent.ExecutionContext = ec
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = ec##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = ec##1
+      |                $continuation.I$1 = y##1
+      |                $continuation.I$2 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3206,44 +2716,17 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                ec##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                ec##1 = $continuation.I$0
+      |                y##1 = $continuation.I$1
+      |                x##1 = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = ec##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = ec##1
+      |                $continuation.I$1 = y##1
+      |                $continuation.I$2 = x##1
+      |                $continuation.I$3 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3254,26 +2737,10 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                ec##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                ec##1 = $continuation.I$0
+      |                y##1 = $continuation.I$1
+      |                x##1 = $continuation.I$2
+      |                z = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -3329,60 +2796,47 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3395,35 +2849,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3434,21 +2868,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -3502,60 +2924,47 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3568,35 +2977,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3607,21 +2996,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -3675,61 +3052,48 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                println("Hello")
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3742,35 +3106,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3781,21 +3125,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -3849,61 +3181,48 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                val w: Int = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3916,35 +3235,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -3955,21 +3254,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -4023,62 +3310,49 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                println("World")
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4091,35 +3365,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4130,21 +3384,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -4198,62 +3440,49 @@ trait StateMachineFixtures {
       |        var y##1: Int = y
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                println("Hello")
       |                val w: Int = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4266,35 +3495,15 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4305,21 +3514,9 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                z = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -4376,66 +3573,50 @@ trait StateMachineFixtures {
       |        var a: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                val w: Int = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4448,44 +3629,17 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4496,26 +3650,10 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                z = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -4572,66 +3710,50 @@ trait StateMachineFixtures {
       |        var a: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                val w: Int = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4644,45 +3766,18 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4693,26 +3788,10 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                z = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -4772,70 +3851,51 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4848,54 +3908,20 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -4906,31 +3932,11 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -4987,66 +3993,50 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                val a: Int = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5059,46 +4049,19 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                b = $continuation.I$2
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
       |                println("World")
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = b
+      |                $continuation.I$3 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5109,26 +4072,10 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                b = $continuation.I$2
+      |                z = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -5188,70 +4135,51 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5264,55 +4192,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                println("Hello")
       |                val c: Int = a.+(b)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5323,31 +4217,11 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -5407,70 +4281,51 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5483,55 +4338,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
       |                val d: Int = c.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5542,31 +4363,11 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                orThrow
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                $result
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -5629,70 +4430,51 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5705,55 +4487,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
       |                val d: Int = c.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5765,31 +4513,11 @@ trait StateMachineFixtures {
       |                w = orThrow.asInstanceOf[Int]
       |                ()
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -5853,70 +4581,51 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5929,55 +4638,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
       |                val d: Int = c.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -5989,31 +4664,11 @@ trait StateMachineFixtures {
       |                w = orThrow.asInstanceOf[Int]
       |                ()
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -6078,70 +4733,51 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -6154,55 +4790,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
       |                val d: Int = c.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -6214,31 +4816,11 @@ trait StateMachineFixtures {
       |                w = orThrow.asInstanceOf[Int]
       |                ()
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -6303,70 +4885,51 @@ trait StateMachineFixtures {
       |        var z: Int = null
       |        var w: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -6379,55 +4942,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
       |                val d: Int = c.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -6439,31 +4968,11 @@ trait StateMachineFixtures {
       |                w = orThrow.asInstanceOf[Int]
       |                ()
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                w = $result.asInstanceOf[Int]
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
@@ -6529,70 +5038,51 @@ trait StateMachineFixtures {
       |        var b: Int = null
       |        var z: Int = null
       |        {
-      |          var $continuation: continuations.Continuation[Any] | Null = null
-      |          completion match
-      |            {
-      |              case x$0 @ <empty> if
-      |                x$0.isInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].&&(
+      |          var $continuation:
+      |            continuations.compileFromString$package.
+      |              compileFromString$package$fooTest$1
+      |           =
+      |            completion match
+      |              {
+      |                case x$0 @ <empty> if
+      |                  x$0.isInstanceOf[
+      |                    continuations.compileFromString$package.
+      |                      compileFromString$package$fooTest$1
+      |                  ].&&(
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.&(scala.Int.MinValue).!=(0)
+      |                  )
+      |                 =>
       |                  x$0.asInstanceOf[
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
-      |                  ].$label.&(scala.Int.MinValue).!=(0)
-      |                )
-      |               =>
-      |                $continuation = x$0
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].$label.-(scala.Int.MinValue)
-      |              case _ =>
-      |                $continuation =
+      |                  ].$label =
+      |                    x$0.asInstanceOf[
+      |                      continuations.compileFromString$package.
+      |                        compileFromString$package$fooTest$1
+      |                    ].$label.-(scala.Int.MinValue)
+      |                  x$0
+      |                case _ =>
       |                  new
       |                    continuations.compileFromString$package.
       |                      compileFromString$package$fooTest$1
       |                  (completion.asInstanceOf[continuations.Continuation[Any | Null]])
-      |            }
+      |              }
       |          val $result: Either[Throwable, Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)] =
-      |            $continuation.asInstanceOf[
-      |              continuations.compileFromString$package.
-      |                compileFromString$package$fooTest$1
-      |            ].$result
-      |          $continuation.asInstanceOf[
-      |            continuations.compileFromString$package.
-      |              compileFromString$package$fooTest$1
-      |          ].$label match
+      |            $continuation.$result
+      |          $continuation.$label match
       |            {
       |              case 0 =>
       |                continuations.Continuation.checkResult($result)
       |                a = 1
       |                b = 1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 1
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.$label = 1
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -6605,55 +5095,21 @@ trait StateMachineFixtures {
       |                return[label1] ()
       |                ()
       |              case 1 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
       |                continuations.Continuation.checkResult($result)
       |                z = $result.asInstanceOf[Int]
       |                label1[Unit]: <empty>
       |                val c: Int = a.+(b)
       |                val d: Int = c.+(1)
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$0 = y##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$1 = x##1
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$2 = a
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$3 = b
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].I$4 = z
-      |                $continuation.asInstanceOf[
-      |                  continuations.compileFromString$package.
-      |                    compileFromString$package$fooTest$1
-      |                ].$label = 2
+      |                $continuation.I$0 = y##1
+      |                $continuation.I$1 = x##1
+      |                $continuation.I$2 = a
+      |                $continuation.I$3 = b
+      |                $continuation.I$4 = z
+      |                $continuation.$label = 2
       |                val safeContinuation: continuations.SafeContinuation[Int] =
       |                  new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int]($continuation)(),
       |                    continuations.Continuation.State.Undecided
@@ -6664,31 +5120,11 @@ trait StateMachineFixtures {
       |                if orThrow.==(continuations.Continuation.State.Suspended) then return continuations.Continuation.State.Suspended
       |                ()
       |              case 2 =>
-      |                y##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$0
-      |                x##1 =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$1
-      |                a =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$2
-      |                b =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$3
-      |                z =
-      |                  $continuation.asInstanceOf[
-      |                    continuations.compileFromString$package.
-      |                      compileFromString$package$fooTest$1
-      |                  ].I$4
+      |                y##1 = $continuation.I$0
+      |                x##1 = $continuation.I$1
+      |                a = $continuation.I$2
+      |                b = $continuation.I$3
+      |                z = $continuation.I$4
       |                continuations.Continuation.checkResult($result)
       |                ()
       |              case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")


### PR DESCRIPTION
- We modify the code generation so that the declaration of the variable `$continuation` and its initialisation, which uses a `match`, all happen in a single statement. 
- We also change the type assigned to the `$continuation` variable, to be an instance of the inner class, so we can save a lot of the `asInstanceOf` statements.