### PR TITLE
Continuation: no either, split methods

### DIFF
--- a/continuationsPlugin/src/it/resources/NonCompanionObject1.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject1.scala
@@ -18,7 +18,7 @@ object ExampleObject {
 
   def continuations(x: Int)(using s: Suspend): Int = {
     s.suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1))
+      continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
     def method4(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject10.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject10.scala
@@ -25,8 +25,8 @@ object ExampleObject {
       val z5 = 1
 
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method4(x) + method5(x) +
-          z1 + z2 + z3 + z4 + z5 + 1))
+        method1(x) + method2(x) + method3(x) + method4(x) + method5(x) +
+          z1 + z2 + z3 + z4 + z5 + 1)
     }
 
     def method6(x: Int) = x + 1
@@ -34,8 +34,8 @@ object ExampleObject {
 
     summon[Suspend].suspendContinuation[Int] { continuation =>
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method6(x) +
-          z1 + z2 + z3 + z4 + z6 + 1))
+        method1(x) + method2(x) + method3(x) + method6(x) +
+          z1 + z2 + z3 + z4 + z6 + 1)
     }
 
     def method7(x: Int) = x + 1
@@ -46,8 +46,8 @@ object ExampleObject {
       val z8 = 1
 
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method7(x) +
-          method8(x) + z1 + z2 + z3 + z4 + z6 + z7 + z8 + 1))
+        method1(x) + method2(x) + method3(x) + method7(x) +
+          method8(x) + z1 + z2 + z3 + z4 + z6 + z7 + z8 + 1)
     }
 
     def method9(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject2.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject2.scala
@@ -15,7 +15,7 @@ object ExampleObject {
       def method2(x: Int) = x + 1
       val z2 = 1
 
-      continuation.resume(Right(method1(x) + method2(x) + z1 + z2 + 1))
+      continuation.resume(method1(x) + method2(x) + z1 + z2 + 1)
     }
 
     def method3(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject3.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject3.scala
@@ -15,7 +15,7 @@ object ExampleObject {
       def method2(x: Int) = x + 1
       val z2 = 1
 
-      continuation.resume(Right(method1(x) + method2(x) + z1 + z2 + 1))
+      continuation.resume(method1(x) + method2(x) + z1 + z2 + 1)
     }
 
     def method3(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject4.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject4.scala
@@ -18,16 +18,16 @@ object ExampleObject {
 
   def continuations(x: Int)(using s: Suspend): Int = {
     val result1 = s.suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1))
+      continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
     s.suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1))
+      continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
     val result2 = s.suspendContinuation[Int] { continuation =>
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1 + result1))
+        method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1 + result1)
     }
 
     def method4(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject5.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject5.scala
@@ -25,8 +25,8 @@ object ExampleObject {
       val z5 = 1
 
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method4(x) + method5(x) +
-          z1 + z2 + z3 + z4 + z5 + 1))
+        method1(x) + method2(x) + method3(x) + method4(x) + method5(x) +
+          z1 + z2 + z3 + z4 + z5 + 1)
     }
 
     def method6(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject6.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject6.scala
@@ -25,8 +25,8 @@ object ExampleObject {
       val z5 = 1
 
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method4(x) + method5(x) +
-          z1 + z2 + z3 + z4 + z5 + 1))
+        method1(x) + method2(x) + method3(x) + method4(x) + method5(x) +
+          z1 + z2 + z3 + z4 + z5 + 1)
     }
 
     def method6(x: Int) = x + 1
@@ -34,8 +34,8 @@ object ExampleObject {
 
     s.suspendContinuation[Int] { continuation =>
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method4(x) + method6(x) +
-          z1 + z2 + z3 + z4 + z6 + 1))
+        method1(x) + method2(x) + method3(x) + method4(x) + method6(x) +
+          z1 + z2 + z3 + z4 + z6 + 1)
     }
 
     def method7(x: Int) = x + 1
@@ -46,8 +46,8 @@ object ExampleObject {
       val z8 = 1
 
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + method4(x) + method6(x) + method7(x) +
-          method8(x) + z1 + z2 + z3 + z4 + z6 + z7 + z8 + 1))
+        method1(x) + method2(x) + method3(x) + method4(x) + method6(x) + method7(x) +
+          method8(x) + z1 + z2 + z3 + z4 + z6 + z7 + z8 + 1)
     }
 
     def method9(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject7.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject7.scala
@@ -18,7 +18,7 @@ object ExampleObject {
 
   def continuations(x: Int): Suspend ?=> Int = {
     summon[Suspend].suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1))
+      continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
     def method4(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject8.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject8.scala
@@ -15,7 +15,7 @@ object ExampleObject {
       def method2(x: Int) = x + 1
       val z2 = 1
 
-      continuation.resume(Right(method1(x) + method2(x) + z1 + z2 + 1))
+      continuation.resume(method1(x) + method2(x) + z1 + z2 + 1)
     }
 
     def method3(x: Int) = x + 1

--- a/continuationsPlugin/src/it/resources/NonCompanionObject9.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject9.scala
@@ -18,16 +18,16 @@ object ExampleObject {
 
   def continuations(x: Int): Suspend ?=> Int = {
     val result1 = summon[Suspend].suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1))
+      continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
     summon[Suspend].suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1))
+      continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
     val result2 = summon[Suspend].suspendContinuation[Int] { continuation =>
       continuation.resume(
-        Right(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1 + result1))
+        method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1 + result1)
     }
 
     def method4(x: Int) = x + 1

--- a/continuationsPlugin/src/main/scala/continuations/Continuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Continuation.scala
@@ -5,7 +5,8 @@ import continuations.jvm.internal.BaseContinuationImpl
 trait Continuation[-A]:
   type Ctx <: Tuple
   def context: Ctx
-  def resume(value: Either[Throwable, A]): Unit
+  def resume(value: A): Unit
+  def raise(error: Throwable): Unit
   def contextService[T](): T | Null =
     context.toList.find(_.isInstanceOf[T]).map(_.asInstanceOf[T]).orNull
 

--- a/continuationsPlugin/src/main/scala/continuations/constants.scala
+++ b/continuationsPlugin/src/main/scala/continuations/constants.scala
@@ -13,3 +13,4 @@ private[continuations] val continuationFullName = s"$continuationPackageName.Con
 private[continuations] val completionParamName = "completion"
 private[continuations] val continuationClassName = "Continuation"
 private[continuations] val resumeMethodName = "resume"
+private[continuations] val raiseMethodName = "raise"

--- a/continuationsPlugin/src/main/scala/continuations/jvm/internal/ContinuationImpl.scala
+++ b/continuationsPlugin/src/main/scala/continuations/jvm/internal/ContinuationImpl.scala
@@ -8,7 +8,10 @@ abstract class BaseContinuationImpl(
       ContinuationStackFrame,
       Serializable:
 
-  final override def resume(result: Either[Throwable, Any | Null]): Unit = {
+  final override def resume(result: Any | Null): Unit = resumeAux(Right(result))
+  final override def raise(error: Throwable): Unit = resumeAux(Left(error))
+
+  private def resumeAux(result: Either[Throwable, Any | Null]): Unit = {
     var current = this
     var param = result
     while true do
@@ -83,5 +86,7 @@ object CompletedContinuation extends Continuation[Any | Null]:
   override type Ctx = Nothing
   override def context: CompletedContinuation.Ctx =
     throw IllegalStateException("Already completed")
-  override def resume(result: Either[Throwable, Any | Null]): Unit =
+  override def resume(result: Any | Null): Unit =
+    throw IllegalStateException("Already completed")
+  override def raise(error: Throwable): Unit =
     throw IllegalStateException("Already completed")

--- a/continuationsPlugin/src/main/scala/continuations/jvm/internal/ContinuationStub.scala
+++ b/continuationsPlugin/src/main/scala/continuations/jvm/internal/ContinuationStub.scala
@@ -6,8 +6,11 @@ object ContinuationStub:
   private def c: Continuation[Any | Null] = new Continuation[Any | Null] {
     type Ctx = EmptyTuple
 
-    def resume(value: Either[Throwable, Any | Null]): Unit =
+    override def resume(value: Any | Null): Unit =
       println("ContinuationStub.resume")
+
+    override def raise(error: Throwable): Unit =
+      println("ContinuationStub.raise")
 
     override def context: Ctx = EmptyTuple
   }

--- a/continuationsPlugin/src/test/resources/DefInsideSuspendExpected.scala
+++ b/continuationsPlugin/src/test/resources/DefInsideSuspendExpected.scala
@@ -14,7 +14,7 @@ package continuations {
         {
           {
             def test(x: Int): Int = x.+(1)
-            safeContinuation.resume(Right.apply[Nothing, Int](test(1).+(1)))
+            safeContinuation.resume(test(1).+(1))
           }
         }
         safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/DefInsideSuspendSource.scala
+++ b/continuationsPlugin/src/test/resources/DefInsideSuspendSource.scala
@@ -3,5 +3,5 @@ package continuations
 def foo(x: Int)(using s: Suspend): Int =
   s.suspendContinuation[Int] { continuation =>
     def test(x: Int) = x + 1
-    continuation.resume(Right(test(1) + 1))
+    continuation.resume(test(1) + 1)
   }

--- a/continuationsPlugin/src/test/resources/OneSuspendContinuation.scala
+++ b/continuationsPlugin/src/test/resources/OneSuspendContinuation.scala
@@ -12,7 +12,7 @@ package continuations {
         val continuation1: continuations.Continuation[Int] = completion
         val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int](continuation1)
         {
-          safeContinuation.resume(Right.apply[Nothing, Int](1))
+          safeContinuation.resume(1)
         }
         safeContinuation.getOrThrow()
       }

--- a/continuationsPlugin/src/test/resources/OneSuspendContinuationFourBlocks.scala
+++ b/continuationsPlugin/src/test/resources/OneSuspendContinuationFourBlocks.scala
@@ -15,7 +15,7 @@ package continuations {
           {
             {
               {
-                safeContinuation.resume(Right.apply[Nothing, Int](1))
+                safeContinuation.resume(1)
               }
             }
           }

--- a/continuationsPlugin/src/test/resources/OneSuspendContinuationThreeBlocks.scala
+++ b/continuationsPlugin/src/test/resources/OneSuspendContinuationThreeBlocks.scala
@@ -14,7 +14,7 @@ package continuations {
         {
           {
             {
-              safeContinuation.resume(Right.apply[Nothing, Int](1))
+              safeContinuation.resume(1)
             }
           }
         }

--- a/continuationsPlugin/src/test/resources/OneSuspendContinuationTwoBlocks.scala
+++ b/continuationsPlugin/src/test/resources/OneSuspendContinuationTwoBlocks.scala
@@ -13,7 +13,7 @@ package continuations {
         val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int](continuation1)
         {
           {
-            safeContinuation.resume(Right.apply[Nothing, Int](1))
+            safeContinuation.resume(1)
           }
         }
         safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineChainedSuspendContinuationsOneParameter.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineChainedSuspendContinuationsOneParameter.scala
@@ -77,7 +77,7 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   {
-                    safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(1)))
+                    safeContinuation.resume(x##1.+(1))
                   }
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
@@ -96,7 +96,7 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   {
-                    safeContinuation.resume(Right.apply[Nothing, Int](y.+(1)))
+                    safeContinuation.resume(y.+(1))
                   }
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =

--- a/continuationsPlugin/src/test/resources/StateMachineChainedSuspendContinuationsOneParameterAndVals.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineChainedSuspendContinuationsOneParameterAndVals.scala
@@ -89,7 +89,7 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   {
-                    safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(w)))
+                    safeContinuation.resume(x##1.+(w))
                   }
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
@@ -113,7 +113,7 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   {
-                    safeContinuation.resume(Right.apply[Nothing, Int](y.+(q).+(x##1)))
+                    safeContinuation.resume(y.+(q).+(x##1))
                   }
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =

--- a/continuationsPlugin/src/test/resources/StateMachineContextFunctionTwoContinuationsChained.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineContextFunctionTwoContinuationsChained.scala
@@ -80,7 +80,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
+                  safeContinuation.resume(x##1.+(y##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -99,7 +99,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineContextFunctionTwoContinuationsChainedExtraGivenParam.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineContextFunctionTwoContinuationsChainedExtraGivenParam.scala
@@ -82,7 +82,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
+                  safeContinuation.resume(x##1.+(y##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -101,7 +101,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineContinuationsInNonCompanionObject.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineContinuationsInNonCompanionObject.scala
@@ -72,11 +72,9 @@ package continuations {
                       {
                         val z4: Int = 1
                         def method4(x: Int): Int = x.+(1)
-                        Right.apply[Nothing, Int](
-                          continuations.ExampleObject.method1(x##1).+(1).+(continuations.ExampleObject.z1).+(z2).+(method2(y##1)).+(z3).+(
-                            method3(x##1)
-                          ).+(z4).+(method4(x##1))
-                        )
+                        continuations.ExampleObject.method1(x##1).+(1).+(continuations.ExampleObject.z1).+(z2).+(method2(y##1)).+(z3).+(method3(x##1)
+                          )
+                        .+(z4).+(method4(x##1))
                       }
                     )
                   }
@@ -98,9 +96,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  {
-                    safeContinuation.resume(Right.apply[Nothing, Int](method1(x##1).+(1)))
-                  }
+                  safeContinuation.resume(method1(x##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -120,7 +116,7 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   {
-                    safeContinuation.resume(Right.apply[Nothing, Int](z5.+(suspension1).+(method5(y##1))))
+                    safeContinuation.resume(z5.+(suspension1).+(method5(y##1)))
                   }
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =

--- a/continuationsPlugin/src/test/resources/StateMachineForOneChainedContinuation.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineForOneChainedContinuation.scala
@@ -72,7 +72,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](1))
+                  safeContinuation.resume(1)
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -87,7 +87,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x.+(1)))
+                  safeContinuation.resume(x.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineForSuspendContinuationReturningANonSuspendingVal.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineForSuspendContinuationReturningANonSuspendingVal.scala
@@ -50,7 +50,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Int](1))
+                        safeContinuation.resume(1)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/resources/StateMachineManyDependantAndNoDependantContinuations.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineManyDependantAndNoDependantContinuations.scala
@@ -90,7 +90,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](qq##1.-(1)))
+                  safeContinuation.resume(qq##1.-(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -112,7 +112,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, String](rr))
+                  safeContinuation.resume(rr)
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -134,7 +134,7 @@ package continuations {
                 $continuation.$label = 3
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](ww.-(1)))
+                  safeContinuation.resume(ww.-(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineManyDependantContinuations.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineManyDependantContinuations.scala
@@ -93,7 +93,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](qq##1.-(1)))
+                  safeContinuation.resume(qq##1.-(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -115,7 +115,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, String](rr))
+                  safeContinuation.resume(rr)
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -140,7 +140,7 @@ package continuations {
                 $continuation.$label = 3
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](ww.-(1)))
+                  safeContinuation.resume(ww.-(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineMultipleChainedSuspendContinuationsReturningANonSuspendedVal.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineMultipleChainedSuspendContinuationsReturningANonSuspendedVal.scala
@@ -84,7 +84,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](1.+(z)))
+                  safeContinuation.resume(1.+(z))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -103,7 +103,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x.+(1).+(q##1)))
+                  safeContinuation.resume(x.+(1).+(q##1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -125,7 +125,7 @@ package continuations {
                 $continuation.$label = 3
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x.+(w).+(1).+(j)))
+                  safeContinuation.resume(x.+(w).+(1).+(j))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal.scala
@@ -50,7 +50,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Int](1))
+                        safeContinuation.resume(1)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -64,7 +64,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Boolean] = continuations.SafeContinuation.init[Boolean]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+                        safeContinuation.resume(false)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -78,7 +78,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+                        safeContinuation.resume("Hello")
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/resources/StateMachineNoDependantSuspensions.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineNoDependantSuspensions.scala
@@ -49,7 +49,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[Boolean] = continuations.SafeContinuation.init[Boolean]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+                      safeContinuation.resume(false)
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -63,7 +63,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+                      safeContinuation.resume("Hello")
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -77,7 +77,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, Int](1))
+                      safeContinuation.resume(1)
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/resources/StateMachineNoDependantSuspensionsWithCodeBetween.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineNoDependantSuspensionsWithCodeBetween.scala
@@ -51,7 +51,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[Boolean] = continuations.SafeContinuation.init[Boolean]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+                      safeContinuation.resume(false)
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -66,7 +66,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+                      safeContinuation.resume("Hello")
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -80,7 +80,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, Int](1))
+                      safeContinuation.resume(1)
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/resources/StateMachineNoDependantSuspensionsWithCodeInside.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineNoDependantSuspensionsWithCodeInside.scala
@@ -50,7 +50,7 @@ package continuations {
                   {
                     {
                       println("Hi")
-                      safeContinuation.resume(Right.apply[Nothing, Boolean](false))
+                      safeContinuation.resume(false)
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -64,7 +64,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+                      safeContinuation.resume("Hello")
                       println("World")
                     }
                   }
@@ -79,7 +79,7 @@ package continuations {
                   val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                   {
                     {
-                      safeContinuation.resume(Right.apply[Nothing, Int](1))
+                      safeContinuation.resume(1)
                     }
                   }
                   val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/resources/StateMachineNoParamOneNoDependantContinuationCodeBeforeUsedAfter.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineNoParamOneNoDependantContinuationCodeBeforeUsedAfter.scala
@@ -75,7 +75,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](10))
+                  safeContinuation.resume(10)
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineOneParamOneDependantContinuation.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineOneParamOneDependantContinuation.scala
@@ -77,7 +77,7 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   {
-                    safeContinuation.resume(Right.apply[Nothing, Int](1))
+                    safeContinuation.resume(1)
                   }
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =

--- a/continuationsPlugin/src/test/resources/StateMachineOneParamOneNoDependantContinuation.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineOneParamOneNoDependantContinuation.scala
@@ -73,7 +73,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Unit] = continuations.SafeContinuation.init[Unit]($continuation)
                 {  
-                  safeContinuation.resume(Right.apply[Nothing, Unit](println(qq##1)))
+                  safeContinuation.resume(println(qq##1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineReturningANonSuspendedValue.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineReturningANonSuspendedValue.scala
@@ -52,7 +52,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Int](1))
+                        safeContinuation.resume(1)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -69,7 +69,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Int](2))
+                        safeContinuation.resume(2)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChained.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChained.scala
@@ -80,7 +80,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
+                  safeContinuation.resume(x##1.+(y##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -99,7 +99,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedExtraGivenParam.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedExtraGivenParam.scala
@@ -86,7 +86,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
+                  safeContinuation.resume(x##1.+(y##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -107,7 +107,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedOneGenericParam.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedOneGenericParam.scala
@@ -112,7 +112,7 @@ package continuations {
                     $continuation.$label = 1
                     val safeContinuation: continuations.SafeContinuation[A] = continuations.SafeContinuation.init[A]($continuation)
                     {
-                      safeContinuation.resume(Right.apply[Nothing, A](a##1))
+                      safeContinuation.resume(a##1)
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                       safeContinuation.getOrThrow()
@@ -132,12 +132,10 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[A] = continuations.SafeContinuation.init[A]($continuation)
                     {
                       safeContinuation.resume(
-                        Right.apply[Nothing, A](
-                          {
-                            println("World")
-                            z
-                          }
-                        )
+                        {
+                          println("World")
+                          z
+                        }
                       )
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedOneLinePrior.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedOneLinePrior.scala
@@ -81,7 +81,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
+                  safeContinuation.resume(x##1.+(y##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -100,7 +100,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedOneValPrior.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedOneValPrior.scala
@@ -81,7 +81,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
+                  safeContinuation.resume(x##1.+(y##1).+(w))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -100,7 +100,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoGenericParams.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoGenericParams.scala
@@ -162,7 +162,7 @@ package continuations {
                     $continuation.$label = 1
                     val safeContinuation: continuations.SafeContinuation[A] = continuations.SafeContinuation.init[A]($continuation)
                     {
-                      safeContinuation.resume(Right.apply[Nothing, A](a##1))
+                      safeContinuation.resume(a##1)
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                       safeContinuation.getOrThrow()
@@ -182,12 +182,10 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[B] = continuations.SafeContinuation.init[B]($continuation)
                     {
                       safeContinuation.resume(
-                        Right.apply[Nothing, B](
-                          {
-                            println(z)
-                            b##1
-                          }
-                        )
+                        {
+                          println(z)
+                          b##1
+                        }
                       )
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoLinesOneValPrior.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoLinesOneValPrior.scala
@@ -82,7 +82,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
+                  safeContinuation.resume(x##1.+(y##1).+(w))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -101,7 +101,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoLinesPrior.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoLinesPrior.scala
@@ -82,7 +82,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(1)))
+                  safeContinuation.resume(x##1.+(y##1).+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -101,7 +101,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(1)))
+                  safeContinuation.resume(z.+(1))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPrior.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPrior.scala
@@ -86,7 +86,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
+                  safeContinuation.resume(x##1.+(y##1).+(w))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -107,7 +107,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(a)))
+                  safeContinuation.resume(z.+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorOneLineBetween.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorOneLineBetween.scala
@@ -86,7 +86,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(w)))
+                  safeContinuation.resume(x##1.+(y##1).+(w))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -108,7 +108,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(a)))
+                  safeContinuation.resume(z.+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorOneValBetween.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorOneValBetween.scala
@@ -90,7 +90,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -114,7 +114,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(b).+(c)))
+                  safeContinuation.resume(z.+(b).+(c))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoLinesBetween.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoLinesBetween.scala
@@ -86,7 +86,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -109,7 +109,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(b)))
+                  safeContinuation.resume(z.+(b))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoLinesOneValBetween.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoLinesOneValBetween.scala
@@ -90,7 +90,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -115,7 +115,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c)))
+                  safeContinuation.resume(z.+(c))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetween.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetween.scala
@@ -90,7 +90,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -115,7 +115,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
+                  safeContinuation.resume(z.+(c).+(d))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenOneLineAfter.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenOneLineAfter.scala
@@ -93,7 +93,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -118,7 +118,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
+                  safeContinuation.resume(z.+(c).+(d))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenOneValAfter.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenOneValAfter.scala
@@ -93,7 +93,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -118,7 +118,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
+                  safeContinuation.resume(z.+(c).+(d))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenTwoLinesAfter.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenTwoLinesAfter.scala
@@ -93,7 +93,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -118,7 +118,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
+                  safeContinuation.resume(z.+(c).+(d))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenTwoValAfter.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenTwoValAfter.scala
@@ -93,7 +93,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -118,7 +118,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
+                  safeContinuation.resume(z.+(c).+(d))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenTwoValAfterChainIgnored.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineTwoContinuationsChainedTwoValPriorTwoValBetweenTwoValAfterChainIgnored.scala
@@ -90,7 +90,7 @@ package continuations {
                 $continuation.$label = 1
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](x##1.+(y##1).+(a)))
+                  safeContinuation.resume(x##1.+(y##1).+(a))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()
@@ -115,7 +115,7 @@ package continuations {
                 $continuation.$label = 2
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
-                  safeContinuation.resume(Right.apply[Nothing, Int](z.+(c).+(d)))
+                  safeContinuation.resume(z.+(c).+(d))
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
                   safeContinuation.getOrThrow()

--- a/continuationsPlugin/src/test/resources/StateMachineWithDependantAndNoDependantContinuationAtTheEnd.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineWithDependantAndNoDependantContinuationAtTheEnd.scala
@@ -78,12 +78,10 @@ package continuations {
                 val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                 {
                   safeContinuation.resume(
-                    Right.apply[Nothing, Int](
-                      {
-                        println("World")
-                        1
-                      }
-                    )
+                    {
+                      println("World")
+                      1
+                    }
                   )
                 }
                 val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) =
@@ -106,12 +104,10 @@ package continuations {
                     val w: String = "World"
                     println("Hello")
                     safeContinuation.resume(
-                      Right.apply[Nothing, Int](
-                        {
-                          println(z)
-                          x##1
-                        }
-                      )
+                      {
+                        println(z)
+                        x##1
+                      }
                     )
                   }
                 }

--- a/continuationsPlugin/src/test/resources/StateMachineWithMultipleResumeReturningANonSuspendedValue.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineWithMultipleResumeReturningANonSuspendedValue.scala
@@ -52,7 +52,7 @@ package continuations {
                       {
                         println("Hello")
                         println("World")
-                        safeContinuation.resume(Right.apply[Nothing, Int](1))
+                        safeContinuation.resume(1)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -66,8 +66,8 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Boolean] = continuations.SafeContinuation.init[Boolean]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Boolean](false))
-                        safeContinuation.resume(Right.apply[Nothing, Boolean](true))
+                        safeContinuation.resume(false)
+                        safeContinuation.resume(true)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 
@@ -81,7 +81,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[String] = continuations.SafeContinuation.init[String]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, String]("Hello"))
+                        safeContinuation.resume("Hello")
                         val x: Int = 1
                         ()
                       }

--- a/continuationsPlugin/src/test/resources/StateMachineWithSingleSuspendedContinuationReturningANonSuspendedVal.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineWithSingleSuspendedContinuationReturningANonSuspendedVal.scala
@@ -54,7 +54,7 @@ package continuations {
                     val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int]($continuation)
                     {
                       {
-                        safeContinuation.resume(Right.apply[Nothing, Int](x##1))
+                        safeContinuation.resume(x##1)
                       }
                     }
                     val orThrow: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State) = 

--- a/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
@@ -17,7 +17,7 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
     """|BodyHasNoSuspensionPoint#apply(defDefTree):
        |def mySuspend()(using Suspend): Int =
        |  summon[Suspend].suspendContinuation[Int] {continuation =>
-       |    continuation.resume(Right(1))
+       |    continuation.resume(1)
        |  }
        |should be some(mySuspend)""".stripMargin) {
     case (given Context, defdef) =>

--- a/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
@@ -13,7 +13,7 @@ class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
     "CallsContinuationResumeWith#apply(defDefTree): def mySuspend()(using Suspend): Int = " +
-      "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) } should be Some(mySuspend)") {
+      "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) } should be Some(mySuspend)") {
     case (given Context, defdef) =>
       // because this is a subtree projection, we cannot use tree
       // equality on the returned trees, as the rightOne fixture and
@@ -32,7 +32,7 @@ class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
 
   continuationsContextAndZeroAritySuspendSuspendingValDef.test(
     "CallsContinuationResumeWith#apply(valDefTree): val mySuspend: Suspend ?=> Int = " +
-      "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) } should be Some(mySuspend)") {
+      "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) } should be Some(mySuspend)") {
     case (given Context, valdef) =>
       assertEquals(CallsSuspendContinuation(valdef), true)
   }

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsChainedTwoArgs.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsChainedTwoArgs.scala
@@ -24,8 +24,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |package continuations
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    s.suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = s.suspendContinuation[Int] { _.resume(x + y + 1) }
+           |    s.suspendContinuation[Int] { _.resume(z + 1) }
            |}
            |""".stripMargin
 
@@ -51,8 +51,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
           |def program: Foo = {
           |
           |  def fooTest[A](a: A, b: Int)(using s: Suspend): A = {
-          |      val z = s.suspendContinuation[A] { _.resume(Right { a }) }
-          |      s.suspendContinuation[A] { _.resume(Right { println("World"); z }) }
+          |      val z = s.suspendContinuation[A] { _.resume(a) }
+          |      s.suspendContinuation[A] { _.resume({ println("World"); z }) }
           |  }
           |  
           |  fooTest(Foo(1), 1)
@@ -82,8 +82,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
           |def program: Bar = {
           |
           |  def fooTest[A, B](a: A, b: B)(using s: Suspend): B = {
-          |      val z = s.suspendContinuation[A] { _.resume(Right { a }) }
-          |      s.suspendContinuation[B] { _.resume(Right { println(z); b }) }
+          |      val z = s.suspendContinuation[A] { _.resume(a) }
+          |      s.suspendContinuation[B] { _.resume({ println(z); b }) }
           |  }
           |
           |  fooTest(Foo(1), Bar(2))
@@ -109,8 +109,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |package continuations
            |
            |def fooTest(x: Int)(y: Int)(using s: Suspend): Int = {
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    s.suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = s.suspendContinuation[Int] { _.resume( { x + y + 1 }) }
+           |    s.suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -135,8 +135,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |import concurrent.ExecutionContext.Implicits.global
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend, ec: ExecutionContext): Int = {
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    s.suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = s.suspendContinuation[Int] { _.resume( { x + y + 1 }) }
+           |    s.suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -162,8 +162,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |import concurrent.ExecutionContext.Implicits.global
            |
            |def fooTest(x: Int, y: Int): (Suspend, ExecutionContext) ?=> Int = {
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume({ z + 1 }) }
            |}
            |""".stripMargin
 
@@ -186,8 +186,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |package continuations
            |
            |def fooTest(x: Int, y: Int): Suspend ?=> Int = {
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -211,8 +211,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    println("Hello")
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -236,8 +236,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + w }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + w }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -262,8 +262,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    println("Hello")
            |    println("World")
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -288,8 +288,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    println("Hello")
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + w }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + 1 }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + w }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -315,8 +315,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + w }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + a }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + w) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + a) }
            |}
            |""".stripMargin
 
@@ -341,9 +341,9 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + w }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + w) }
            |    println("Hello")
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + a }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + a) }
            |}
            |""".stripMargin
 
@@ -369,9 +369,9 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + 1
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + b + c }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + b + c) }
            |}
            |""".stripMargin
 
@@ -397,10 +397,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
            |    println("Hello")
            |    println("World")
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + b }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + b) }
            |}
            |""".stripMargin
 
@@ -426,10 +426,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
            |    println("Hello")
            |    val c = a + b
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + c }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + c) }
            |}
            |""".stripMargin
 
@@ -455,10 +455,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(Right { z + c + d }) }
+           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + c + d) }
            |}
            |""".stripMargin
 
@@ -484,10 +484,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(Right { z + c + d }) }
+           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
            |    println(w)
            |}
            |""".stripMargin
@@ -514,10 +514,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(Right { z + c + d }) }
+           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
            |    val e = w + 1
            |    e
            |}
@@ -545,10 +545,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(Right { z + c + d }) }
+           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
            |    val e = w + 1
            |    println(e)
            |}
@@ -576,10 +576,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(Right { z + c + d }) }
+           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
            |    val e = w + 1
            |    val f = z + w + a
            |    e + f
@@ -608,10 +608,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(Right { x + y + a }) }
+           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    s.suspendContinuation[Int] { _.resume(Right { z + c + d }) }
+           |    s.suspendContinuation[Int] { _.resume(z + c + d) }
            |    val e = z + 1
            |    val f = z + a
            |    e + f

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -143,7 +143,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using Suspend): Int = {
            |  val x = 5
            |  println("HI")
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |}
            |""".stripMargin
       checkCompile("pickleQuotes", source) {
@@ -301,7 +301,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -320,7 +320,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(Right(1)))
+           |  summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(1))
            |""".stripMargin
 
       checkContinuations(source) {
@@ -339,7 +339,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right(1)) }
+           |  summon[Suspend].suspendContinuation[Int] { _.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -358,7 +358,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int](_.resume(Right(1)))
+           |  summon[Suspend].suspendContinuation[Int](_.resume(1))
            |""".stripMargin
 
       checkContinuations(source) {
@@ -377,7 +377,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Left(new Exception("error"))) }
+           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.raise(new Exception("error")) }
            |""".stripMargin
 
       // format: off
@@ -398,7 +398,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |        val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int](continuation1)
            |        {
            |          {
-           |            safeContinuation.resume(Left.apply[Exception, Nothing](new Exception("error")))
+           |            safeContinuation.raise(new Exception("error"))
            |          }
            |        }
            |        safeContinuation.getOrThrow()
@@ -425,10 +425,10 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using Suspend): Int =
            |  summon[Suspend].suspendContinuation[Int]{ c =>
            |    println("Hello")
-           |    c.resume(Right(1))
+           |    c.resume(1)
            |    val x = 1
            |    val y = false
-           |    c.resume(Right(2))
+           |    c.resume(2)
            |    println(x)
            |  }
            |""".stripMargin
@@ -452,10 +452,10 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |        {
            |          {
            |            println("Hello")
-           |            safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |            safeContinuation.resume(1)
            |            val x: Int = 1
            |            val y: Boolean = false
-           |            safeContinuation.resume(Right.apply[Nothing, Int](2))
+           |            safeContinuation.resume(2)
            |            println(x)
            |          }
            |        }
@@ -486,7 +486,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |      println("Hello")
            |      val x = 1
            |      val y = 1
-           |      Right(x + y)
+           |      x + y
            |    }
            |  }
            |""".stripMargin
@@ -514,7 +514,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |                println("Hello")
            |                val x: Int = 1
            |                val y: Int = 1
-           |                Right.apply[Nothing, Int](x.+(y))
+           |                x.+(y)
            |              }
            |            )
            |          }
@@ -540,7 +540,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using s: Suspend): Int =
-           |  s.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  s.suspendContinuation[Int] { continuation => continuation.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -559,7 +559,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(): Suspend ?=> Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -580,7 +580,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using Suspend): Int = {
            |  val x = 5
            |  println("HI")
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |}
            |""".stripMargin
 
@@ -605,7 +605,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |          val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int](continuation1)
            |          {
            |            {
-           |              safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |              safeContinuation.resume(1)
            |            }
            |          }
            |          safeContinuation.getOrThrow()
@@ -677,7 +677,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(x: Int)(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(x + 1)) }
+           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(x + 1) }
            |""".stripMargin
 
       // format: off
@@ -698,7 +698,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |        val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int](continuation1)
            |        {
            |          {
-           |            safeContinuation.resume(Right.apply[Nothing, Int](x.+(1)))
+           |            safeContinuation.resume(x.+(1))
            |          }
            |        }
            |        safeContinuation.getOrThrow()
@@ -724,7 +724,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |    10
            |  }
            |  foo()
@@ -737,7 +737,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo(): Suspend ?=> Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |    10
            |  }
            |  foo()
@@ -769,7 +769,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo(x: Int)(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(x)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(x) }
            |    10
            |  }
            |  foo(11)
@@ -797,7 +797,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  if (x < y) then {
            |    x
            |  } else {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |  }
            |}
            |""".stripMargin
@@ -829,7 +829,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |              val safeContinuation: continuations.SafeContinuation[Int] = continuations.SafeContinuation.init[Int](continuation1)
            |              {
            |                {
-           |                  safeContinuation.resume(Right.apply[Nothing, Int](1))
+           |                  safeContinuation.resume(1)
            |                }
            |              }
            |              safeContinuation.getOrThrow()
@@ -857,9 +857,9 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(false) }
+           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume("Hello") }
            |    10
            |  }
            |
@@ -889,14 +889,14 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |    summon[Suspend].suspendContinuation[Int] { continuation =>
            |      println("Hello")
            |      println("World")
-           |      continuation.resume(Right(1))
+           |      continuation.resume(1)
            |    }
            |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
-           |      continuation.resume(Right(false))
-           |      continuation.resume(Right(true))
+           |      continuation.resume(false)
+           |      continuation.resume(true)
            |    }
            |    summon[Suspend].suspendContinuation[String] { continuation =>
-           |      continuation.resume(Right("Hello"))
+           |      continuation.resume("Hello")
            |      val x = 1
            |    }
            |    10
@@ -925,11 +925,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
            |    println("Start")
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |    val x = "World"
            |    println("Hello")
            |    println(x)
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
            |    println("End")
            |    10
            |  }
@@ -944,11 +944,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def program: Int = {
            |  def foo(): Suspend ?=> Int = {
            |    println("Start")
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |    val x = "World"
            |    println("Hello")
            |    println(x)
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
            |    println("End")
            |    10
            |  }
@@ -981,9 +981,9 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(false) }
+           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume("Hello") }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |  }
            |
            |foo()
@@ -1010,13 +1010,13 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  def foo()(using Suspend): Int = {
            |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
            |      println("Hi")
-           |      continuation.resume(Right(false))
+           |      continuation.resume(false)
            |    }
            |    summon[Suspend].suspendContinuation[String] {
-           |      continuation => continuation.resume(Right("Hello"))
+           |      continuation => continuation.resume("Hello")
            |      println("World")
            |    }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |  }
            |
            |foo()
@@ -1043,10 +1043,10 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  def foo()(using Suspend): Int = {
            |    println("Start")
            |    val x = 1
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
+           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(false) }
            |    println("Hello")
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume("Hello") }
+           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |  }
            |
            |foo()
@@ -1087,7 +1087,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo[A, B](x: A, y: B)(z: String)(using s: Suspend, ec: ExecutionContext): A =
-           |    summon[Suspend].suspendContinuation[A] { continuation => continuation.resume(Right(x)) }
+           |    summon[Suspend].suspendContinuation[A] { continuation => continuation.resume(x) }
            |  foo(1,2)("A")
            |}
            |""".stripMargin
@@ -1138,7 +1138,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |            val safeContinuation: continuations.SafeContinuation[A] = continuations.SafeContinuation.init[A](continuation1)
            |            {
            |              {
-           |                safeContinuation.resume(Right.apply[Nothing, A](x))
+           |                safeContinuation.resume(x)
            |              }
            |            }
            |            safeContinuation.getOrThrow()
@@ -1173,7 +1173,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(x: Int)(using Suspend): Int = {
-           |  val y = summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+           |  val y = summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
            |  x + y
            |}
            |""".stripMargin
@@ -1196,7 +1196,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(qq: Int)(using s: Suspend): Int = {
-           |  summon[Suspend].suspendContinuation[Unit] { _.resume(Right { println(qq) }) }
+           |  summon[Suspend].suspendContinuation[Unit] { _.resume({ println(qq) }) }
            |  10
            |}
            |""".stripMargin
@@ -1222,7 +1222,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using s: Suspend): Int = {
            |  val xx = 111
            |  println(xx)
-           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right( 10 )) }
+           |  summon[Suspend].suspendContinuation[Int] { _.resume( 10 ) }
            |  xx
            |}
            |""".stripMargin
@@ -1248,12 +1248,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(qq: Int)(using s: Suspend): Int = {
            |    val pp = 11
-           |    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
+           |    val xx = s.suspendContinuation[Int] { _.resume(qq - 1) }
            |    val ww = 13
            |    val rr = "AAA"
-           |    val yy = s.suspendContinuation[String] { _.resume(Right { rr }) }
+           |    val yy = s.suspendContinuation[String] { _.resume(rr) }
            |    val tt = 100
-           |    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
+           |    val zz = s.suspendContinuation[Int] { _.resume(ww - 1) }
            |    println(xx)
            |    xx + qq + yy.size + zz + pp + tt
            |}
@@ -1279,12 +1279,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(qq: Int)(using s: Suspend): Int = {
            |    val pp = 11
-           |    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
+           |    val xx = s.suspendContinuation[Int] { _.resume(qq - 1) }
            |    val ww = 13
            |    val rr = "AAA"
-           |    s.suspendContinuation[String] { _.resume(Right { rr }) }
+           |    s.suspendContinuation[String] { _.resume(rr) }
            |    val tt = 100
-           |    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
+           |    val zz = s.suspendContinuation[Int] { _.resume(ww - 1) }
            |    println(xx)
            |    xx + qq + zz + pp + tt
            |}
@@ -1311,12 +1311,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(x: Int)(using s: Suspend): Int = {
            |    println("Hello")
-           |    val y = s.suspendContinuation[Int] { _.resume(Right { println("World"); 1 }) }
+           |    val y = s.suspendContinuation[Int] { _.resume( { println("World"); 1 }) }
            |    val z = 1
            |    s.suspendContinuation[Int] { continuation =>
            |      val w = "World"
            |      println("Hello")
-           |      continuation.resume(Right { println(z); x })
+           |      continuation.resume( { println(z); x })
            |    }
            |    val tt = 2
            |    x + y + tt
@@ -1342,8 +1342,8 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def fooTest()(using s: Suspend): Int = {
-           |    val x = s.suspendContinuation[Int] { _.resume(Right { 1 }) }
-           |    s.suspendContinuation[Int] { _.resume(Right { x + 1 }) }
+           |    val x = s.suspendContinuation[Int] { _.resume(1) }
+           |    s.suspendContinuation[Int] { _.resume(x + 1) }
            |}
            |""".stripMargin
 
@@ -1368,11 +1368,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def fooTest(q: Int)(using s: Suspend): Int = {
            |    println("Hello")
            |    val z = 100
-           |    val x = s.suspendContinuation[Int] { _.resume(Right { 1 + z}) }
+           |    val x = s.suspendContinuation[Int] { _.resume(1 + z) }
            |    val j = 9
-           |    val w = s.suspendContinuation[Int] { _.resume(Right { x + 1 + q}) }
+           |    val w = s.suspendContinuation[Int] { _.resume(x + 1 + q) }
            |    println("World")
-           |    s.suspendContinuation[Int] { _.resume(Right { x + w + 1 + j}) }
+           |    s.suspendContinuation[Int] { _.resume(x + w + 1 + j) }
            |    10
            |}
            |""".stripMargin
@@ -1485,10 +1485,10 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(x: Int)(using Suspend): Int = {
            |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(x + 1))
+           |      continuation.resume(x + 1)
            |    }
            |    summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(y + 1))
+           |      continuation.resume(y + 1)
            |    }
            |}
            |""".stripMargin
@@ -1515,12 +1515,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |    val q = 2
            |    val w = 3
            |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(x + w))
+           |      continuation.resume(x + w)
            |    }
            |    val p = 1
            |    val t = 1
            |    val z = summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(y + q + x))
+           |      continuation.resume(y + q + x)
            |    }
            |    z + y + p
            |}
@@ -1647,17 +1647,17 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
           |        val z4 = 1
           |        def method4(x: Int) = x + 1
           |
-          |        Right(method1(x) + 1 + z1 + z2 + method2(y) + z3 + method3(x) + z4 + method4(x))
+          |        method1(x) + 1 + z1 + z2 + method2(y) + z3 + method3(x) + z4 + method4(x)
           |      }
           |    }
           |
-          |    s.suspendContinuation[Int] { continuation => continuation.resume(Right(method1(x) + 1)) }
+          |    s.suspendContinuation[Int] { _.resume(method1(x) + 1) }
           |
           |    val z5 = suspension1
           |    def method5(x: Int) = x + 1
           |
           |    val suspension2 = s.suspendContinuation[Int] { continuation =>
-          |      continuation.resume(Right(z5 + suspension1 + method5(y)))
+          |      continuation.resume(z5 + suspension1 + method5(y))
           |    }
           |
           |    val z6 = 1

--- a/continuationsPlugin/src/test/scala/continuations/TreesChecksSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/TreesChecksSuite.scala
@@ -9,8 +9,8 @@ import munit.FunSuite
 class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
 
   continuationsContextAndInlinedSuspendingTree.test(
-    """|subtreeCallsSuspend(Suspend#suspendContinuation[Int] {continuation =>
-       |  continuation.resume(Right(1))
+    """|subtreeCallsSuspend(Suspend#suspendContinuation[Int] { continuation =>
+       |  continuation.resume(1)
        |})
        | should be true""".stripMargin) {
     case (given Context, inlinedSuspend) =>
@@ -18,28 +18,27 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
   }
 
   continuationsContextAndOneTree.test(
-    """|subtreeCallsSuspend(1) should be false""".stripMargin) {
+    "subtreeCallsSuspend(1) should be false".stripMargin) {
     case (given Context, nonInlinedTree) =>
       assert(!subtreeCallsSuspend(nonInlinedTree))
   }
 
   continuationsContextAndInlinedSuspendingTree.test(
     """|treeCallsSuspend(Suspend#suspendContinuation[Int] {continuation =>
-       |  continuation.resume(Right(1))
+       |  continuation.resume(1)
        |})
        | should be true""".stripMargin) {
     case (given Context, inlinedSuspend) =>
       assert(treeCallsSuspend(inlinedSuspend))
   }
 
-  continuationsContextAndOneTree.test("""|treeCallsSuspend(1) should be false""".stripMargin) {
+  continuationsContextAndOneTree.test("treeCallsSuspend(1) should be false".stripMargin) {
     case (given Context, nonInlinedTree) =>
       assert(!treeCallsSuspend(nonInlinedTree))
   }
 
   continuationsContextAndInlinedSuspendingTree.test(
-    """|treeCallsResume(continuation.resume(Right(1)))
-       | should be true""".stripMargin) {
+    "treeCallsResume(continuation.resume(1)) should be true".stripMargin) {
     case (given Context, inlinedSuspend) =>
       val resume = inlinedSuspend match
         case Inlined(
@@ -55,7 +54,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
   continuationsContextAndInlinedSuspendingTree.test(
     """
       |treeCallsResume(Suspend#suspendContinuation[Int] {continuation =>
-      |  continuation.resume(Right(1))
+      |  continuation.resume(1)
       |})
       | should be false
       |""".stripMargin) {
@@ -65,7 +64,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
 
   continutationsContextAndInlinedSuspendingSingleArityWithDependentNonSuspendingCalculation
     .test("""|valDefTreeCallsSuspend(val y = Suspend#suspendContinuation[Int] {continuation =>
-             |  continuation.resume(Right(x+1))
+             |  continuation.resume(x+1)
              |})
              | should be true""".stripMargin) {
       case (given Context, tree) =>
@@ -78,7 +77,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
 
   continuationsContextAndInlinedSuspendingTree.test(
     """|valDefTreeCallsSuspend(Suspend#suspendContinuation[Int] {continuation =>
-       |  continuation.resume(Right(1))
+       |  continuation.resume(1)
        |})
        | should be false""".stripMargin) {
     case (given Context, tree) =>

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -233,7 +233,7 @@ object ExampleObject:
         val z4 = 1
         def method4(x: Int) = x
 
-        Right(method1(x) + 1 + z1 + z2 + method2(y) + z3 + method3(x) + z4 + method4(x))
+        method1(x) + 1 + z1 + z2 + method2(y) + z3 + method3(x) + z4 + method4(x)
       }
     }
 

--- a/continuationsPluginExample/src/main/scala/examples/GenericArgumentsContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/GenericArgumentsContinuations.scala
@@ -5,8 +5,8 @@ import continuations.Suspend
 @main def GenericArgumentsContinuations =
   def genericArgumentsContinuations[A](x: A)(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x)))
+      continuation.resume(println(x))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
 
   println(genericArgumentsContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/LeftContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/LeftContinuation.scala
@@ -7,6 +7,6 @@ import scala.util.Try
 @main def LeftContinuation: Unit =
   def left()(using s: Suspend): Int =
     s.suspendContinuation[Int] { continuation =>
-      continuation.resume(Left(new Exception("error")))
+      continuation.raise(new Exception("error"))
     }
   println(Try(left()))

--- a/continuationsPluginExample/src/main/scala/examples/ListMap.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ListMap.scala
@@ -6,7 +6,7 @@ import continuations.Suspend
   def twoArgumentsOneContinuationsCFBefore(x: Int, y: Int): Suspend ?=> Int =
     val z = 1
     summon[Suspend].suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(x + y + z))
+      continuation.resume(x + y + z)
     }
   val mappedContinuations = List(1, 2, 3, 4).map(twoArgumentsOneContinuationsCFBefore(1, _))
   println(mappedContinuations)

--- a/continuationsPluginExample/src/main/scala/examples/MultipleSuspendWithExpressionsInBody.scala
+++ b/continuationsPluginExample/src/main/scala/examples/MultipleSuspendWithExpressionsInBody.scala
@@ -11,7 +11,7 @@ import continuations.Suspend
     s.suspendContinuation[Boolean] { continuation =>
       val q = "World"
       println("Hi")
-      continuation.resume(Right { println(q); false })
+      continuation.resume({ println(q); false })
     }
     10
 

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentOneContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentOneContinuations.scala
@@ -7,6 +7,6 @@ import continuations.Suspend
   def oneArgumentOneAdditionalGivenArgumentOneContinuations(
       x: Int)(using Suspend, String): String =
     summon[Suspend].suspendContinuation[String] { continuation =>
-      continuation.resume(Right(summon[String] + x))
+      continuation.resume(summon[String] + x)
     }
   println(oneArgumentOneAdditionalGivenArgumentOneContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentTwoContinuations.scala
@@ -7,7 +7,7 @@ import continuations.Suspend
   def oneArgumentOneAdditionalGivenArgumentTwoContinuations(
       x: Int)(using Suspend, String): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(summon[String] + x)))
+      continuation.resume(println(summon[String] + x))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
   println(oneArgumentOneAdditionalGivenArgumentTwoContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuations.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def OneArgumentsSingleResumeContinuations =
   def oneArgumentsSingleResumeContinuations(x: Int)(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation => continuation.resume(Right(x + 1)) }
+    s.suspendContinuation[Int] { continuation => continuation.resume(x + 1) }
   println(oneArgumentsSingleResumeContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuationsBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuationsBefore.scala
@@ -6,5 +6,5 @@ import continuations.Suspend
   def oneArgumentsSingleResumeContinuationsBefore(x: Int)(using Suspend): Int =
     println("Hello")
     val y = x
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
   println(oneArgumentsSingleResumeContinuationsBefore(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuations.scala
@@ -4,6 +4,6 @@ import continuations.Suspend
 
 @main def OneArgumentsTwoContinuations =
   def oneArgumentsTwoContinuations(x: Int)(using s: Suspend): Int =
-    s.suspendContinuation[Unit] { continuation => continuation.resume(Right(println(x))) }
-    s.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    s.suspendContinuation[Unit] { continuation => continuation.resume(println(x)) }
+    s.suspendContinuation[Int] { continuation => continuation.resume(1) }
   println(oneArgumentsTwoContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuationsCF.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def OneArgumentsTwoContinuationsCF =
   def oneArgumentsTwoContinuationsCF(x: Int): Suspend ?=> Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x)))
+      continuation.resume(println(x))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
   println(oneArgumentsTwoContinuationsCF(1))

--- a/continuationsPluginExample/src/main/scala/examples/ProgramMultipleSuspendLeft.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ProgramMultipleSuspendLeft.scala
@@ -5,6 +5,6 @@ import scala.util.Try
 
 @main def ProgramMultipleSuspendLeft =
   def foo()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { _.resume(Left(new Exception("error"))) }
-    s.suspendContinuation[Int] { _.resume(Right { println("Resume2"); 2 }) }
+    s.suspendContinuation[Int] { _.raise(new Exception("error")) }
+    s.suspendContinuation[Int] { _.resume({ println("Resume2"); 2 }) }
   println(Try(foo()))

--- a/continuationsPluginExample/src/main/scala/examples/ResumeWithValsInsideTheContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ResumeWithValsInsideTheContinuation.scala
@@ -7,6 +7,6 @@ import continuations.Suspend
     s.suspendContinuation[Int] { continuation =>
       val x = 1
       val y = 2
-      continuation.resume(Right(x + y))
+      continuation.resume(x + y)
     }
   println(resumeWithValsInsideTheContinuation())

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuations.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def TwoArgumentsSingleResumeContinuations =
   def twoArgumentsSingleResumeContinuations(x: Int, y: Int)(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation => continuation.resume(Right(x + y + 1)) }
+    s.suspendContinuation[Int] { continuation => continuation.resume(x + y + 1) }
   println(twoArgumentsSingleResumeContinuations(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsBeforeUsedInResume.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsBeforeUsedInResume.scala
@@ -7,5 +7,5 @@ import continuations.Suspend
       using s: Suspend): Int =
     println("Hello")
     val z = 1
-    s.suspendContinuation[Int] { continuation => continuation.resume(Right(x + y + z)) }
+    s.suspendContinuation[Int] { continuation => continuation.resume(x + y + z) }
   println(twoArgumentsSingleResumeContinuationsBeforeUsedInResume(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def TwoArgumentsTwoContinuations =
   def twoArgumentsTwoContinuations(x: Int, y: Int)(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x + y)))
+      continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
   println(twoArgumentsTwoContinuations(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuationsCF.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def TwoArgumentsTwoContinuationsCF =
   def twoArgumentsTwoContinuationsCF(x: Int, y: Int): Suspend ?=> Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x + y)))
+      continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(3)) }
+    summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(3))
   println(twoArgumentsTwoContinuationsCF(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsOneContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsOneContinuations.scala
@@ -5,6 +5,6 @@ import continuations.Suspend
 @main def TwoCurriedArgumentsOneContinuations =
   def twoCurriedArgumentsOneContinuations(x: Int)(y: Int)(using Suspend): Int =
     summon[Suspend].suspendContinuation[Int] { continuation =>
-      continuation.resume(Right(x + y + 1))
+      continuation.resume(x + y + 1)
     }
   println(twoCurriedArgumentsOneContinuations(1)(1))

--- a/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsTwoContinuations.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def TwoCurriedArgumentsTwoContinuations =
   def twoCurriedArgumentsTwoContinuations(x: Int)(y: Int)(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x + y)))
+      continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(3)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(3) }
   println(twoCurriedArgumentsTwoContinuations(1)(2))

--- a/continuationsPluginExample/src/main/scala/examples/UseValsDefinedInsideContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/UseValsDefinedInsideContinuation.scala
@@ -8,6 +8,6 @@ import continuations.Suspend
       val x = 1
       val y = 2
       x + y
-      continuation.resume(Right(3))
+      continuation.resume(3)
     }
   println(useValsDefinedInsideContinuation())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeAfter.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeAfter.scala
@@ -5,10 +5,10 @@ import continuations.Suspend
 @main def ZeroArgumentsCodeAfter =
   def zeroArgumentsCodeAfter()(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(1)))
+      continuation.resume(println(1))
     }
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(2)))
+      continuation.resume(println(2))
     }
     3
   println(zeroArgumentsCodeAfter())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBefore.scala
@@ -7,7 +7,7 @@ import continuations.Suspend
     println("Hello")
     val x = 1
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(1)))
+      continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsCodeBefore())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBetween.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBetween.scala
@@ -5,9 +5,9 @@ import continuations.Suspend
 @main def ZeroArgumentsCodeBetween =
   def zeroArgumentsCodeBetween()(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(1)))
+      continuation.resume(println(1))
     }
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsCodeBetween())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuations.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def ZeroArgumentsSingleResumeContinuations =
   def zeroArgumentsSingleResumeContinuations()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    s.suspendContinuation[Int] { continuation => continuation.resume(1) }
   println(zeroArgumentsSingleResumeContinuations())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuationsBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuationsBefore.scala
@@ -6,5 +6,5 @@ import continuations.Suspend
   def zeroArgumentsSingleResumeContinuationsBefore()(using Suspend): Int =
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
   println(zeroArgumentsSingleResumeContinuationsBefore())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuations.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def ZeroArgumentsTwoContinuations =
   def zeroArgumentsTwoContinuations()(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(1)))
+      continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsTwoContinuations())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuationsCF.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def ZeroArgumentsTwoContinuationsCF =
   def zeroArgumentsTwoContinuationsCF(): Suspend ?=> Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(1)))
+      continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsTwoContinuationsCF())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedAboveContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedAboveContinuation.scala
@@ -7,8 +7,8 @@ import continuations.Suspend
     println("Hello")
     val x = 1
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x)))
+      continuation.resume(println(x))
     }
     val y = 2
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(y)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(y) }
   println(zeroArgumentsValsDefinedAboveContinuation())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedInsideContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedInsideContinuation.scala
@@ -6,11 +6,11 @@ import continuations.Suspend
   def zeroArgumentsValsDefinedInsideContinuation()(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
       val x = 1
-      continuation.resume(Right(println(x)))
+      continuation.resume(println(x))
     }
     val x = 1
     summon[Suspend].suspendContinuation[Int] { continuation =>
       val x = 2
-      continuation.resume(Right(x))
+      continuation.resume(x)
     }
   println(zeroArgumentsValsDefinedInsideContinuation())

--- a/two-arguments-two-continuations/src/main/scala/examples/ProgramSuspendingContinuationNoParamResumeIgnoreResult.scala
+++ b/two-arguments-two-continuations/src/main/scala/examples/ProgramSuspendingContinuationNoParamResumeIgnoreResult.scala
@@ -11,10 +11,10 @@ import continuations.*
     s.suspendContinuation[Boolean] { continuation =>
       val q = "World"
       println("Hi")
-      continuation.resume(Right { println(q); false })
+      continuation.resume({ println(q); false })
     }
     s.suspendContinuation[Int] { continuation =>
-      continuation.resume(Left(new Exception("error")))
+      continuation.raise(new Exception("error"))
     }
     10
   fooTest()

--- a/two-arguments-two-continuations/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
+++ b/two-arguments-two-continuations/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def TwoArgumentsTwoContinuations =
   def twoArgumentsTwoContinuations(x: Int, y: Int)(using Suspend): Int =
     summon[Suspend].suspendContinuation[Unit] { continuation =>
-      continuation.resume(Right(println(x + y)))
+      continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
   println(twoArgumentsTwoContinuations(1, 2))


### PR DESCRIPTION
Currently the `continuation` class has a `resume` method that takes either an error or a result, but we think we can split that into two cases.