### PR TITLE
Rename "suspendContinuation" to "shift"

### DIFF
--- a/continuationsPlugin/src/it/resources/NonCompanionObject1.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject1.scala
@@ -17,7 +17,7 @@ object ExampleObject {
   val z3 = 1
 
   def continuations(x: Int)(using s: Suspend): Int = {
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject10.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject10.scala
@@ -20,7 +20,7 @@ object ExampleObject {
     def method4(x: Int) = x + 1
     val z4 = 1
 
-    val result1 = summon[Suspend].suspendContinuation[Int] { continuation =>
+    val result1 = summon[Suspend].shift[Int] { continuation =>
       def method5(x: Int) = x + 1
       val z5 = 1
 
@@ -32,7 +32,7 @@ object ExampleObject {
     def method6(x: Int) = x + 1
     val z6 = 1
 
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       continuation.resume(
         method1(x) + method2(x) + method3(x) + method6(x) +
           z1 + z2 + z3 + z4 + z6 + 1)
@@ -41,7 +41,7 @@ object ExampleObject {
     def method7(x: Int) = x + 1
     val z7 = 1
 
-    val result2 = summon[Suspend].suspendContinuation[Int] { continuation =>
+    val result2 = summon[Suspend].shift[Int] { continuation =>
       def method8(x: Int) = x + 1
       val z8 = 1
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject2.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject2.scala
@@ -11,7 +11,7 @@ object ExampleObject {
     def method1(x: Int) = x + 1
     val z1 = 1
 
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       def method2(x: Int) = x + 1
       val z2 = 1
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject3.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject3.scala
@@ -11,7 +11,7 @@ object ExampleObject {
     def method1(x: Int) = x + 1
     val z1 = 1
 
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       def method2(x: Int) = x + 1
       val z2 = 1
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject4.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject4.scala
@@ -17,15 +17,15 @@ object ExampleObject {
   val z3 = 1
 
   def continuations(x: Int)(using s: Suspend): Int = {
-    val result1 = s.suspendContinuation[Int] { continuation =>
+    val result1 = s.shift[Int] { continuation =>
       continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
-    val result2 = s.suspendContinuation[Int] { continuation =>
+    val result2 = s.shift[Int] { continuation =>
       continuation.resume(
         method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1 + result1)
     }

--- a/continuationsPlugin/src/it/resources/NonCompanionObject5.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject5.scala
@@ -20,7 +20,7 @@ object ExampleObject {
     def method4(x: Int) = x + 1
     val z4 = 1
 
-    val result1 = s.suspendContinuation[Int] { continuation =>
+    val result1 = s.shift[Int] { continuation =>
       def method5(x: Int) = x + 1
       val z5 = 1
 
@@ -32,7 +32,7 @@ object ExampleObject {
     def method6(x: Int) = x + 1
     val z6 = 1
 
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       continuation.resume(
         method1(x) + method2(x) + method3(x) + method6(x) +
           z1 + z2 + z3 + z4 + z6 + 1)
@@ -41,7 +41,7 @@ object ExampleObject {
     def method7(x: Int) = x + 1
     val z7 = 1
 
-    val result2 = s.suspendContinuation[Int] { continuation =>
+    val result2 = s.shift[Int] { continuation =>
       def method8(x: Int) = x + 1
       val z8 = 1
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject6.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject6.scala
@@ -20,7 +20,7 @@ object ExampleObject {
     def method4(x: Int) = x + 1
     val z4 = 1
 
-    val result1 = s.suspendContinuation[Int] { continuation =>
+    val result1 = s.shift[Int] { continuation =>
       def method5(x: Int) = x + 1
       val z5 = 1
 
@@ -32,7 +32,7 @@ object ExampleObject {
     def method6(x: Int) = x + 1
     val z6 = 1
 
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       continuation.resume(
         method1(x) + method2(x) + method3(x) + method4(x) + method6(x) +
           z1 + z2 + z3 + z4 + z6 + 1)
@@ -41,7 +41,7 @@ object ExampleObject {
     def method7(x: Int) = x + 1
     val z7 = 1
 
-    val result2 = s.suspendContinuation[Int] { continuation =>
+    val result2 = s.shift[Int] { continuation =>
       def method8(x: Int) = x + 1
       val z8 = 1
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject7.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject7.scala
@@ -17,7 +17,7 @@ object ExampleObject {
   val z3 = 1
 
   def continuations(x: Int): Suspend ?=> Int = {
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject8.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject8.scala
@@ -11,7 +11,7 @@ object ExampleObject {
     def method1(x: Int) = x + 1
     val z1 = 1
 
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       def method2(x: Int) = x + 1
       val z2 = 1
 

--- a/continuationsPlugin/src/it/resources/NonCompanionObject9.scala
+++ b/continuationsPlugin/src/it/resources/NonCompanionObject9.scala
@@ -17,15 +17,15 @@ object ExampleObject {
   val z3 = 1
 
   def continuations(x: Int): Suspend ?=> Int = {
-    val result1 = summon[Suspend].suspendContinuation[Int] { continuation =>
+    val result1 = summon[Suspend].shift[Int] { continuation =>
       continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       continuation.resume(method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1)
     }
 
-    val result2 = summon[Suspend].suspendContinuation[Int] { continuation =>
+    val result2 = summon[Suspend].shift[Int] { continuation =>
       continuation.resume(
         method1(x) + method2(x) + method3(x) + z1 + z2 + z3 + 1 + result1)
     }

--- a/continuationsPlugin/src/main/scala/continuations/CallsSuspendContinuation.scala
+++ b/continuationsPlugin/src/main/scala/continuations/CallsSuspendContinuation.scala
@@ -7,14 +7,14 @@ import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.report
 
 /**
- * Matcher for detecting methods that call [[continuations.Suspend#suspendContinuation]]
+ * Matcher for detecting methods that call [[continuations.Suspend#shift]]
  */
 private[continuations] object CallsSuspendContinuation extends TreesChecks:
 
   private def hasNestedContinuation(tree: Tree)(using Context): Boolean =
     tree.existsSubTree {
       case Inlined(call, _, _) =>
-        call.denot.matches(suspendContinuationMethod.symbol)
+        call.denot.matches(shiftMethod.symbol)
       case _ => false
     }
 
@@ -22,8 +22,8 @@ private[continuations] object CallsSuspendContinuation extends TreesChecks:
    * @param tree
    *   the [[dotty.tools.dotc.ast.tpd.Tree]] to match upon
    * @return
-   *   [[scala.Some]] if the tree contains a subtree call to
-   *   [[continuations.Suspend#suspendContinuation]], [[scala.None]] otherwise
+   *   [[scala.Some]] if the tree contains a subtree call to [[continuations.Suspend#shift]],
+   *   [[scala.None]] otherwise
    */
   def apply(tree: ValOrDefDef)(using Context): Boolean =
     val args =
@@ -31,7 +31,7 @@ private[continuations] object CallsSuspendContinuation extends TreesChecks:
         .rhs
         .filterSubTrees {
           case Inlined(call, _, _) =>
-            val isSuspendContinuation = call.denot.matches(suspendContinuationMethod.symbol)
+            val isSuspendContinuation = call.denot.matches(shiftMethod.symbol)
             if isSuspendContinuation && hasNestedContinuation(call) then
               report.error(
                 "Suspension functions can be called only within coroutine body",

--- a/continuationsPlugin/src/main/scala/continuations/HasSuspensionNotInReturnedValue.scala
+++ b/continuationsPlugin/src/main/scala/continuations/HasSuspensionNotInReturnedValue.scala
@@ -5,8 +5,8 @@ import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.Context
 
 /**
- * Matcher for detecting methods that calls/returns
- * [[continuations.Suspend#suspendContinuation]] but not in their last row
+ * Matcher for detecting methods that calls/returns [[continuations.Suspend#shift]] but not in
+ * their last row
  */
 private[continuations] object HasSuspensionNotInReturnedValue extends TreesChecks:
 
@@ -14,9 +14,8 @@ private[continuations] object HasSuspensionNotInReturnedValue extends TreesCheck
    * @param tree
    *   the [[dotty.tools.dotc.ast.tpd.Tree]] to match upon
    * @return
-   *   [[scala.Some]] with the tree if it calls [[continuations.Suspend#suspendContinuation]]
-   *   and [[continuations.Continuation.resume]] but not in the last row, [[scala.None]]
-   *   otherwise
+   *   [[scala.Some]] with the tree if it calls [[continuations.Suspend#shift]] and
+   *   [[continuations.Continuation.resume]] but not in the last row, [[scala.None]] otherwise
    */
   def apply(tree: ValOrDefDef)(using Context): Boolean =
     val rhs =

--- a/continuationsPlugin/src/main/scala/continuations/Suspend.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Suspend.scala
@@ -6,7 +6,7 @@ sealed trait Suspend:
   def continuation[A](f: Continuation[A] => Unit): A
 
   extension (s: Suspend)
-    inline def suspendContinuation[A](f: Continuation[A] => Unit): A =
+    inline def shift[A](f: Continuation[A] => Unit): A =
       throw CompilerRewriteUnsuccessfulException
 
 object Suspend:

--- a/continuationsPlugin/src/main/scala/continuations/Trees.scala
+++ b/continuationsPlugin/src/main/scala/continuations/Trees.scala
@@ -6,8 +6,8 @@ import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.Symbols.{requiredClass, requiredClassRef}
 
 trait Trees {
-  private[continuations] def suspendContinuationMethod(using Context): Select =
-    ref(requiredClass(suspendFullName)).select(termName(suspendContinuationName))
+  private[continuations] def shiftMethod(using Context): Select =
+    ref(requiredClass(suspendFullName)).select(termName(shiftName))
 
   private[continuations] def continuationResumeMethod(using Context) =
     requiredClassRef(continuationFullName).select(termName(resumeName))

--- a/continuationsPlugin/src/main/scala/continuations/TreesChecks.scala
+++ b/continuationsPlugin/src/main/scala/continuations/TreesChecks.scala
@@ -8,14 +8,13 @@ trait TreesChecks extends Trees {
 
   /**
    * @param tree
-   *   A [[dotty.tools.dotc.ast.tpd.Tree]] to check if
-   *   [[continuations.Suspend#suspendContinuation]] is called
+   *   A [[dotty.tools.dotc.ast.tpd.Tree]] to check if [[continuations.Suspend#shift]] is called
    * @return
-   *   True if the calls calls the method [[continuations.Suspend#suspendContinuation]]
+   *   True if the calls calls the method [[continuations.Suspend#shift]]
    */
   private[continuations] def subtreeCallsSuspend(tree: Tree)(using Context): Boolean =
     val treeIsContinuationsSuspendContinuation: Context ?=> Tree => Boolean = t =>
-      t.denot.matches(suspendContinuationMethod.symbol)
+      t.denot.matches(shiftMethod.symbol)
 
     tree.existsSubTree {
       case Inlined(call, _, _) => treeIsContinuationsSuspendContinuation(call)
@@ -24,14 +23,13 @@ trait TreesChecks extends Trees {
 
   /**
    * @param tree
-   *   A [[dotty.tools.dotc.ast.tpd.Tree]] to check if it calls
-   *   [[continuations.Suspend#suspendContinuation]]
+   *   A [[dotty.tools.dotc.ast.tpd.Tree]] to check if it calls [[continuations.Suspend#shift]]
    * @return
-   *   True if the tree calls the method [[continuations.Suspend#suspendContinuation]]
+   *   True if the tree calls the method [[continuations.Suspend#shift]]
    */
   private[continuations] def treeCallsSuspend(tree: Tree)(using Context): Boolean =
     val treeIsContinuationsSuspendContinuation: Context ?=> Tree => Boolean = t =>
-      t.denot.matches(suspendContinuationMethod.symbol)
+      t.denot.matches(shiftMethod.symbol)
 
     tree match
       case Inlined(call, _, _) => treeIsContinuationsSuspendContinuation(call)

--- a/continuationsPlugin/src/main/scala/continuations/constants.scala
+++ b/continuationsPlugin/src/main/scala/continuations/constants.scala
@@ -6,7 +6,7 @@ import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.Symbols.requiredClass
 
 private[continuations] val continuationPackageName = "continuations"
-private[continuations] val suspendContinuationName = "suspendContinuation"
+private[continuations] val shiftName = "shift"
 private[continuations] val resumeName = "resume"
 private[continuations] val suspendFullName = s"$continuationPackageName.Suspend"
 private[continuations] val continuationFullName = s"$continuationPackageName.Continuation"

--- a/continuationsPlugin/src/main/scala/continuations/intrinsics/IntrinsicsJvm.scala
+++ b/continuationsPlugin/src/main/scala/continuations/intrinsics/IntrinsicsJvm.scala
@@ -11,7 +11,7 @@ extension [A](continuation: Continuation[A])
 
 extension [A](suspendedFn: Suspend ?=> A)
 
-  // inline def suspendContinuation
+  // inline def shift
   /*
   suspend inline fun <T> suspendCoroutineUninterceptedOrReturn(
       crossinline block: (Continuation<T>) -> Any?

--- a/continuationsPlugin/src/test/resources/DefInsideSuspendSource.scala
+++ b/continuationsPlugin/src/test/resources/DefInsideSuspendSource.scala
@@ -1,7 +1,7 @@
 package continuations
 
 def foo(x: Int)(using s: Suspend): Int =
-  s.suspendContinuation[Int] { continuation =>
+  s.shift[Int] { continuation =>
     def test(x: Int) = x + 1
     continuation.resume(test(1) + 1)
   }

--- a/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/BodyHasSuspensionPointSuite.scala
@@ -16,7 +16,7 @@ class BodyHasSuspensionPointSuite extends FunSuite, CompilerFixtures:
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
     """|BodyHasNoSuspensionPoint#apply(defDefTree):
        |def mySuspend()(using Suspend): Int =
-       |  summon[Suspend].suspendContinuation[Int] {continuation =>
+       |  summon[Suspend].shift[Int] {continuation =>
        |    continuation.resume(1)
        |  }
        |should be some(mySuspend)""".stripMargin) {

--- a/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CallsSuspendContinuationSuite.scala
@@ -13,7 +13,7 @@ class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
 
   continuationsContextAndZeroAritySuspendSuspendingDefDef.test(
     "CallsContinuationResumeWith#apply(defDefTree): def mySuspend()(using Suspend): Int = " +
-      "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) } should be Some(mySuspend)") {
+      "summon[Suspend].shift[Int] { continuation => continuation.resume(1) } should be Some(mySuspend)") {
     case (given Context, defdef) =>
       // because this is a subtree projection, we cannot use tree
       // equality on the returned trees, as the rightOne fixture and
@@ -32,7 +32,7 @@ class CallsSuspendContinuationSuite extends FunSuite, CompilerFixtures:
 
   continuationsContextAndZeroAritySuspendSuspendingValDef.test(
     "CallsContinuationResumeWith#apply(valDefTree): val mySuspend: Suspend ?=> Int = " +
-      "summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) } should be Some(mySuspend)") {
+      "summon[Suspend].shift[Int] { continuation => continuation.resume(1) } should be Some(mySuspend)") {
     case (given Context, valdef) =>
       assertEquals(CallsSuspendContinuation(valdef), true)
   }

--- a/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/CompilerFixtures.scala
@@ -364,7 +364,7 @@ trait CompilerFixtures { self: FunSuite =>
     teardown = _ => ()
   )
 
-  val suspendContinuation = FunFixture[Context ?=> Inlined](
+  val shift = FunFixture[Context ?=> Inlined](
     setup = _ => inlinedCallToContinuationsSuspendOfInt,
     teardown = _ => ()
   )
@@ -503,7 +503,7 @@ trait CompilerFixtures { self: FunSuite =>
               ValDef(
                 y.asTerm,
                 ref(usingSuspendArg)
-                  .select(Names.termName(suspendContinuationName))
+                  .select(Names.termName(shiftName))
                   .appliedTo(ref(usingSuspendArg))
                   .appliedToType(intType)
                   .appliedTo(
@@ -567,7 +567,7 @@ trait CompilerFixtures { self: FunSuite =>
                 y.asTerm,
                 Inlined(
                   ref(usingSuspendArg)
-                    .select(Names.termName(suspendContinuationName))
+                    .select(Names.termName(shiftName))
                     .appliedTo(ref(usingSuspendArg))
                     .appliedToType(intType)
                     .appliedTo(
@@ -670,7 +670,7 @@ trait CompilerFixtures { self: FunSuite =>
     )
 
   val continuationsContextAndInlinedSuspendingTree =
-    FunFixture.map2(compilerContextWithContinuationsPlugin, suspendContinuation)
+    FunFixture.map2(compilerContextWithContinuationsPlugin, shift)
 
   val continuationsContextAndOneTree =
     FunFixture.map2(compilerContextWithContinuationsPlugin, oneTree)
@@ -882,7 +882,7 @@ trait CompilerFixtures { self: FunSuite =>
       Apply(
         TypeApply(
           Apply(
-            ref(suspend).select(Names.termName("suspendContinuation")),
+            ref(suspend).select(Names.termName("shift")),
             List(ref(suspend))
           ),
           List(TypeTree(intType))),

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsChainedTwoArgs.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsChainedTwoArgs.scala
@@ -24,8 +24,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |package continuations
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
-           |    val z = s.suspendContinuation[Int] { _.resume(x + y + 1) }
-           |    s.suspendContinuation[Int] { _.resume(z + 1) }
+           |    val z = s.shift[Int] { _.resume(x + y + 1) }
+           |    s.shift[Int] { _.resume(z + 1) }
            |}
            |""".stripMargin
 
@@ -51,8 +51,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
           |def program: Foo = {
           |
           |  def fooTest[A](a: A, b: Int)(using s: Suspend): A = {
-          |      val z = s.suspendContinuation[A] { _.resume(a) }
-          |      s.suspendContinuation[A] { _.resume({ println("World"); z }) }
+          |      val z = s.shift[A] { _.resume(a) }
+          |      s.shift[A] { _.resume({ println("World"); z }) }
           |  }
           |  
           |  fooTest(Foo(1), 1)
@@ -82,8 +82,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
           |def program: Bar = {
           |
           |  def fooTest[A, B](a: A, b: B)(using s: Suspend): B = {
-          |      val z = s.suspendContinuation[A] { _.resume(a) }
-          |      s.suspendContinuation[B] { _.resume({ println(z); b }) }
+          |      val z = s.shift[A] { _.resume(a) }
+          |      s.shift[B] { _.resume({ println(z); b }) }
           |  }
           |
           |  fooTest(Foo(1), Bar(2))
@@ -109,8 +109,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |package continuations
            |
            |def fooTest(x: Int)(y: Int)(using s: Suspend): Int = {
-           |    val z = s.suspendContinuation[Int] { _.resume( { x + y + 1 }) }
-           |    s.suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = s.shift[Int] { _.resume( { x + y + 1 }) }
+           |    s.shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -135,8 +135,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |import concurrent.ExecutionContext.Implicits.global
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend, ec: ExecutionContext): Int = {
-           |    val z = s.suspendContinuation[Int] { _.resume( { x + y + 1 }) }
-           |    s.suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = s.shift[Int] { _.resume( { x + y + 1 }) }
+           |    s.shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -162,8 +162,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |import concurrent.ExecutionContext.Implicits.global
            |
            |def fooTest(x: Int, y: Int): (Suspend, ExecutionContext) ?=> Int = {
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume({ z + 1 }) }
+           |    val z = summon[Suspend].shift[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].shift[Int] { _.resume({ z + 1 }) }
            |}
            |""".stripMargin
 
@@ -186,8 +186,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |package continuations
            |
            |def fooTest(x: Int, y: Int): Suspend ?=> Int = {
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = summon[Suspend].shift[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -211,8 +211,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    println("Hello")
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = summon[Suspend].shift[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -236,8 +236,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + w }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = summon[Suspend].shift[Int] { _.resume( { x + y + w }) }
+           |    summon[Suspend].shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -262,8 +262,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    println("Hello")
            |    println("World")
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + 1 }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = summon[Suspend].shift[Int] { _.resume( { x + y + 1 }) }
+           |    summon[Suspend].shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -288,8 +288,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    println("Hello")
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume( { x + y + w }) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume( { z + 1 }) }
+           |    val z = summon[Suspend].shift[Int] { _.resume( { x + y + w }) }
+           |    summon[Suspend].shift[Int] { _.resume( { z + 1 }) }
            |}
            |""".stripMargin
 
@@ -315,8 +315,8 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + w) }
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + a) }
+           |    val z = summon[Suspend].shift[Int] { _.resume(x + y + w) }
+           |    summon[Suspend].shift[Int] { _.resume(z + a) }
            |}
            |""".stripMargin
 
@@ -341,9 +341,9 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val w = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + w) }
+           |    val z = summon[Suspend].shift[Int] { _.resume(x + y + w) }
            |    println("Hello")
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + a) }
+           |    summon[Suspend].shift[Int] { _.resume(z + a) }
            |}
            |""".stripMargin
 
@@ -369,9 +369,9 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = summon[Suspend].shift[Int] { _.resume(x + y + a) }
            |    val c = a + 1
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + b + c) }
+           |    summon[Suspend].shift[Int] { _.resume(z + b + c) }
            |}
            |""".stripMargin
 
@@ -397,10 +397,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = summon[Suspend].shift[Int] { _.resume(x + y + a) }
            |    println("Hello")
            |    println("World")
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + b) }
+           |    summon[Suspend].shift[Int] { _.resume(z + b) }
            |}
            |""".stripMargin
 
@@ -426,10 +426,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = summon[Suspend].shift[Int] { _.resume(x + y + a) }
            |    println("Hello")
            |    val c = a + b
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + c) }
+           |    summon[Suspend].shift[Int] { _.resume(z + c) }
            |}
            |""".stripMargin
 
@@ -455,10 +455,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = summon[Suspend].shift[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    summon[Suspend].suspendContinuation[Int] { _.resume(z + c + d) }
+           |    summon[Suspend].shift[Int] { _.resume(z + c + d) }
            |}
            |""".stripMargin
 
@@ -484,10 +484,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = s.shift[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
+           |    val w = s.shift[Int] { _.resume(z + c + d) }
            |    println(w)
            |}
            |""".stripMargin
@@ -514,10 +514,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Int = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = s.shift[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
+           |    val w = s.shift[Int] { _.resume(z + c + d) }
            |    val e = w + 1
            |    e
            |}
@@ -545,10 +545,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = s.shift[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
+           |    val w = s.shift[Int] { _.resume(z + c + d) }
            |    val e = w + 1
            |    println(e)
            |}
@@ -576,10 +576,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = s.shift[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    val w = s.suspendContinuation[Int] { _.resume(z + c + d) }
+           |    val w = s.shift[Int] { _.resume(z + c + d) }
            |    val e = w + 1
            |    val f = z + w + a
            |    e + f
@@ -608,10 +608,10 @@ class ContinuationsChainedTwoArgs extends FunSuite, CompilerFixtures, StateMachi
            |def fooTest(x: Int, y: Int)(using s: Suspend): Unit = {
            |    val a = 1
            |    val b = 1
-           |    val z = s.suspendContinuation[Int] { _.resume(x + y + a) }
+           |    val z = s.shift[Int] { _.resume(x + y + a) }
            |    val c = a + b
            |    val d = c + 1
-           |    s.suspendContinuation[Int] { _.resume(z + c + d) }
+           |    s.shift[Int] { _.resume(z + c + d) }
            |    val e = z + 1
            |    val f = z + a
            |    e + f

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -143,7 +143,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using Suspend): Int = {
            |  val x = 5
            |  println("HI")
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |  summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |}
            |""".stripMargin
       checkCompile("pickleQuotes", source) {
@@ -301,7 +301,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |  summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -320,7 +320,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(1))
+           |  summon[Suspend].shift[Int](continuation => continuation.resume(1))
            |""".stripMargin
 
       checkContinuations(source) {
@@ -339,7 +339,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { _.resume(1) }
+           |  summon[Suspend].shift[Int] { _.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -358,7 +358,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int](_.resume(1))
+           |  summon[Suspend].shift[Int](_.resume(1))
            |""".stripMargin
 
       checkContinuations(source) {
@@ -377,7 +377,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.raise(new Exception("error")) }
+           |  summon[Suspend].shift[Int] { continuation => continuation.raise(new Exception("error")) }
            |""".stripMargin
 
       // format: off
@@ -423,7 +423,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int]{ c =>
+           |  summon[Suspend].shift[Int]{ c =>
            |    println("Hello")
            |    c.resume(1)
            |    val x = 1
@@ -481,7 +481,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int]{ c =>
+           |  summon[Suspend].shift[Int]{ c =>
            |    c.resume{
            |      println("Hello")
            |      val x = 1
@@ -540,7 +540,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using s: Suspend): Int =
-           |  s.suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |  s.shift[Int] { continuation => continuation.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -559,7 +559,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(): Suspend ?=> Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |  summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |""".stripMargin
 
       checkContinuations(source) {
@@ -580,7 +580,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using Suspend): Int = {
            |  val x = 5
            |  println("HI")
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |  summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |}
            |""".stripMargin
 
@@ -630,7 +630,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { _ => val x = 1; println("Hello") }
+           |  summon[Suspend].shift[Int] { _ => val x = 1; println("Hello") }
            |""".stripMargin
 
       // format: off
@@ -677,7 +677,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(x: Int)(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(x + 1) }
+           |  summon[Suspend].shift[Int] { continuation => continuation.resume(x + 1) }
            |""".stripMargin
 
       // format: off
@@ -724,7 +724,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |    10
            |  }
            |  foo()
@@ -737,7 +737,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo(): Suspend ?=> Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |    10
            |  }
            |  foo()
@@ -769,7 +769,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo(x: Int)(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(x) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(x) }
            |    10
            |  }
            |  foo(11)
@@ -797,7 +797,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  if (x < y) then {
            |    x
            |  } else {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |  }
            |}
            |""".stripMargin
@@ -848,7 +848,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` that returns " +
+    "it should convert simple suspended def with no parameters with multiple `shift` that returns " +
       "a non-suspending value into a state machine including an update of the call site:") {
     case given Context =>
       val source =
@@ -857,9 +857,9 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(false) }
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume("Hello") }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Boolean] { continuation => continuation.resume(false) }
+           |    summon[Suspend].shift[String] { continuation => continuation.resume("Hello") }
            |    10
            |  }
            |
@@ -876,8 +876,8 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` that returns " +
-      "a non-suspending value and with multiple expressions in the suspendContinuation body into a state machine " +
+    "it should convert simple suspended def with no parameters with multiple `shift` that returns " +
+      "a non-suspending value and with multiple expressions in the shift body into a state machine " +
       "including an update of the call site:") {
     case given Context =>
       val source =
@@ -886,16 +886,16 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation =>
+           |    summon[Suspend].shift[Int] { continuation =>
            |      println("Hello")
            |      println("World")
            |      continuation.resume(1)
            |    }
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
+           |    summon[Suspend].shift[Boolean] { continuation =>
            |      continuation.resume(false)
            |      continuation.resume(true)
            |    }
-           |    summon[Suspend].suspendContinuation[String] { continuation =>
+           |    summon[Suspend].shift[String] { continuation =>
            |      continuation.resume("Hello")
            |      val x = 1
            |    }
@@ -925,11 +925,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
            |    println("Start")
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |    val x = "World"
            |    println("Hello")
            |    println(x)
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
            |    println("End")
            |    10
            |  }
@@ -944,11 +944,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def program: Int = {
            |  def foo(): Suspend ?=> Int = {
            |    println("Start")
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |    val x = "World"
            |    println("Hello")
            |    println(x)
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
            |    println("End")
            |    10
            |  }
@@ -972,7 +972,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
+    "it should convert simple suspended def with no parameters with multiple `shift` " +
       "into a state machine including an update of the call site:") {
     case given Context =>
       val source =
@@ -981,9 +981,9 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(false) }
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume("Hello") }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Boolean] { continuation => continuation.resume(false) }
+           |    summon[Suspend].shift[String] { continuation => continuation.resume("Hello") }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |  }
            |
            |foo()
@@ -999,8 +999,8 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
-      "and with multiple expressions in the suspendContinuation body into a state machine including an update of the call site:") {
+    "it should convert simple suspended def with no parameters with multiple `shift` " +
+      "and with multiple expressions in the shift body into a state machine including an update of the call site:") {
     case given Context =>
       val source =
         """|
@@ -1008,15 +1008,15 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
+           |    summon[Suspend].shift[Boolean] { continuation =>
            |      println("Hi")
            |      continuation.resume(false)
            |    }
-           |    summon[Suspend].suspendContinuation[String] {
+           |    summon[Suspend].shift[String] {
            |      continuation => continuation.resume("Hello")
            |      println("World")
            |    }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |  }
            |
            |foo()
@@ -1032,7 +1032,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
+    "it should convert simple suspended def with no parameters with multiple `shift` " +
       "and with expressions between them into a state machine including an update of the call site:") {
     case given Context =>
       val source =
@@ -1043,10 +1043,10 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |  def foo()(using Suspend): Int = {
            |    println("Start")
            |    val x = 1
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(false) }
+           |    summon[Suspend].shift[Boolean] { continuation => continuation.resume(false) }
            |    println("Hello")
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume("Hello") }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |    summon[Suspend].shift[String] { continuation => continuation.resume("Hello") }
+           |    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |  }
            |
            |foo()
@@ -1087,7 +1087,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def program: Int = {
            |  def foo[A, B](x: A, y: B)(z: String)(using s: Suspend, ec: ExecutionContext): A =
-           |    summon[Suspend].suspendContinuation[A] { continuation => continuation.resume(x) }
+           |    summon[Suspend].shift[A] { continuation => continuation.resume(x) }
            |  foo(1,2)("A")
            |}
            |""".stripMargin
@@ -1166,14 +1166,14 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
   }
 
   compilerContextWithContinuationsPlugin.test(
-    "it should transform a dependent suspendContinuation with one param into a state machine") {
+    "it should transform a dependent shift with one param into a state machine") {
     case given Context =>
       val source =
         """|
            |package continuations
            |
            |def foo(x: Int)(using Suspend): Int = {
-           |  val y = summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+           |  val y = summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
            |  x + y
            |}
            |""".stripMargin
@@ -1196,7 +1196,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def foo(qq: Int)(using s: Suspend): Int = {
-           |  summon[Suspend].suspendContinuation[Unit] { _.resume({ println(qq) }) }
+           |  summon[Suspend].shift[Unit] { _.resume({ println(qq) }) }
            |  10
            |}
            |""".stripMargin
@@ -1222,7 +1222,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def foo()(using s: Suspend): Int = {
            |  val xx = 111
            |  println(xx)
-           |  summon[Suspend].suspendContinuation[Int] { _.resume( 10 ) }
+           |  summon[Suspend].shift[Int] { _.resume( 10 ) }
            |  xx
            |}
            |""".stripMargin
@@ -1248,12 +1248,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(qq: Int)(using s: Suspend): Int = {
            |    val pp = 11
-           |    val xx = s.suspendContinuation[Int] { _.resume(qq - 1) }
+           |    val xx = s.shift[Int] { _.resume(qq - 1) }
            |    val ww = 13
            |    val rr = "AAA"
-           |    val yy = s.suspendContinuation[String] { _.resume(rr) }
+           |    val yy = s.shift[String] { _.resume(rr) }
            |    val tt = 100
-           |    val zz = s.suspendContinuation[Int] { _.resume(ww - 1) }
+           |    val zz = s.shift[Int] { _.resume(ww - 1) }
            |    println(xx)
            |    xx + qq + yy.size + zz + pp + tt
            |}
@@ -1279,12 +1279,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(qq: Int)(using s: Suspend): Int = {
            |    val pp = 11
-           |    val xx = s.suspendContinuation[Int] { _.resume(qq - 1) }
+           |    val xx = s.shift[Int] { _.resume(qq - 1) }
            |    val ww = 13
            |    val rr = "AAA"
-           |    s.suspendContinuation[String] { _.resume(rr) }
+           |    s.shift[String] { _.resume(rr) }
            |    val tt = 100
-           |    val zz = s.suspendContinuation[Int] { _.resume(ww - 1) }
+           |    val zz = s.shift[Int] { _.resume(ww - 1) }
            |    println(xx)
            |    xx + qq + zz + pp + tt
            |}
@@ -1311,9 +1311,9 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |
            |def fooTest(x: Int)(using s: Suspend): Int = {
            |    println("Hello")
-           |    val y = s.suspendContinuation[Int] { _.resume( { println("World"); 1 }) }
+           |    val y = s.shift[Int] { _.resume( { println("World"); 1 }) }
            |    val z = 1
-           |    s.suspendContinuation[Int] { continuation =>
+           |    s.shift[Int] { continuation =>
            |      val w = "World"
            |      println("Hello")
            |      continuation.resume( { println(z); x })
@@ -1342,8 +1342,8 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def fooTest()(using s: Suspend): Int = {
-           |    val x = s.suspendContinuation[Int] { _.resume(1) }
-           |    s.suspendContinuation[Int] { _.resume(x + 1) }
+           |    val x = s.shift[Int] { _.resume(1) }
+           |    s.shift[Int] { _.resume(x + 1) }
            |}
            |""".stripMargin
 
@@ -1368,11 +1368,11 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def fooTest(q: Int)(using s: Suspend): Int = {
            |    println("Hello")
            |    val z = 100
-           |    val x = s.suspendContinuation[Int] { _.resume(1 + z) }
+           |    val x = s.shift[Int] { _.resume(1 + z) }
            |    val j = 9
-           |    val w = s.suspendContinuation[Int] { _.resume(x + 1 + q) }
+           |    val w = s.shift[Int] { _.resume(x + 1 + q) }
            |    println("World")
-           |    s.suspendContinuation[Int] { _.resume(x + w + 1 + j) }
+           |    s.shift[Int] { _.resume(x + w + 1 + j) }
            |    10
            |}
            |""".stripMargin
@@ -1484,10 +1484,10 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |package continuations
            |
            |def fooTest(x: Int)(using Suspend): Int = {
-           |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
+           |    val y = summon[Suspend].shift[Int] { continuation =>
            |      continuation.resume(x + 1)
            |    }
-           |    summon[Suspend].suspendContinuation[Int] { continuation =>
+           |    summon[Suspend].shift[Int] { continuation =>
            |      continuation.resume(y + 1)
            |    }
            |}
@@ -1514,12 +1514,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
            |def fooTest(x: Int)(using Suspend): Int = {
            |    val q = 2
            |    val w = 3
-           |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
+           |    val y = summon[Suspend].shift[Int] { continuation =>
            |      continuation.resume(x + w)
            |    }
            |    val p = 1
            |    val t = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { continuation =>
+           |    val z = summon[Suspend].shift[Int] { continuation =>
            |      continuation.resume(y + q + x)
            |    }
            |    z + y + p
@@ -1639,7 +1639,7 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
           |    def method2(x: Int) = x + 1
           |    val z2 = 1
           |
-          |    val suspension1 = s.suspendContinuation[Int] { continuation =>
+          |    val suspension1 = s.shift[Int] { continuation =>
           |      def method3(x: Int) = x + 1
           |      val z3 = 1
           |
@@ -1651,12 +1651,12 @@ class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineF
           |      }
           |    }
           |
-          |    s.suspendContinuation[Int] { _.resume(method1(x) + 1) }
+          |    s.shift[Int] { _.resume(method1(x) + 1) }
           |
           |    val z5 = suspension1
           |    def method5(x: Int) = x + 1
           |
-          |    val suspension2 = s.suspendContinuation[Int] { continuation =>
+          |    val suspension2 = s.shift[Int] { continuation =>
           |      continuation.resume(z5 + suspension1 + method5(y))
           |    }
           |

--- a/continuationsPlugin/src/test/scala/continuations/SuspendSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/SuspendSuite.scala
@@ -3,10 +3,9 @@ package continuations
 import munit.FunSuite
 
 class SuspendSuite extends FunSuite {
-  test(
-    "suspendContinuation should throw a CompilerRewriteUnsuccessfulException if it is not converted") {
+  test("shift should throw a CompilerRewriteUnsuccessfulException if it is not converted") {
     def foo()(using Suspend): Int =
-      summon[Suspend].suspendContinuation[Int] { _ => () }
+      summon[Suspend].shift[Int] { _ => () }
 
     intercept[Suspend.CompilerRewriteUnsuccessfulException.type](foo())
   }

--- a/continuationsPlugin/src/test/scala/continuations/SuspensionPointsSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/SuspensionPointsSuite.scala
@@ -16,7 +16,7 @@ class SuspensionPointsSuite extends FunSuite, CompilerFixtures, Trees {
           obtained.size == 2 &&
             obtained.headOption.exists { case vd: ValDef => vd.name.show == "y" } &&
             obtained.lastOption.exists {
-              case Inlined(call, _, _) => call.symbol.matches(suspendContinuationMethod.symbol)
+              case Inlined(call, _, _) => call.symbol.matches(shiftMethod.symbol)
             })
     }
 

--- a/continuationsPlugin/src/test/scala/continuations/TreesChecksSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/TreesChecksSuite.scala
@@ -9,7 +9,7 @@ import munit.FunSuite
 class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
 
   continuationsContextAndInlinedSuspendingTree.test(
-    """|subtreeCallsSuspend(Suspend#suspendContinuation[Int] { continuation =>
+    """|subtreeCallsSuspend(Suspend#shift[Int] { continuation =>
        |  continuation.resume(1)
        |})
        | should be true""".stripMargin) {
@@ -23,7 +23,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
   }
 
   continuationsContextAndInlinedSuspendingTree.test(
-    """|treeCallsSuspend(Suspend#suspendContinuation[Int] {continuation =>
+    """|treeCallsSuspend(Suspend#shift[Int] {continuation =>
        |  continuation.resume(1)
        |})
        | should be true""".stripMargin) {
@@ -52,7 +52,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
 
   continuationsContextAndInlinedSuspendingTree.test(
     """
-      |treeCallsResume(Suspend#suspendContinuation[Int] {continuation =>
+      |treeCallsResume(Suspend#shift[Int] {continuation =>
       |  continuation.resume(1)
       |})
       | should be false
@@ -62,7 +62,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
   }
 
   continutationsContextAndInlinedSuspendingSingleArityWithDependentNonSuspendingCalculation
-    .test("""|valDefTreeCallsSuspend(val y = Suspend#suspendContinuation[Int] {continuation =>
+    .test("""|valDefTreeCallsSuspend(val y = Suspend#shift[Int] {continuation =>
              |  continuation.resume(x+1)
              |})
              | should be true""".stripMargin) {
@@ -75,7 +75,7 @@ class TreesChecksSuite extends FunSuite, CompilerFixtures, TreesChecks {
     }
 
   continuationsContextAndInlinedSuspendingTree.test(
-    """|valDefTreeCallsSuspend(Suspend#suspendContinuation[Int] {continuation =>
+    """|valDefTreeCallsSuspend(Suspend#shift[Int] {continuation =>
        |  continuation.resume(1)
        |})
        | should be false""".stripMargin) {

--- a/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
+++ b/continuationsPluginExample/src/main/scala/examples/CPSExample.scala
@@ -14,7 +14,7 @@ import scala.util.Try
 import concurrent.ExecutionContext.Implicits.global
 
 def await[A](future: Future[A]): A =
-  Suspend.given_Suspend.suspendContinuation { (c: Continuation[A]) =>
+  Suspend.given_Suspend.shift { (c: Continuation[A]) =>
     future.onComplete {
       case Success(value) => c.resume(value)
       case Failure(exception) => c.raise(exception)
@@ -129,7 +129,7 @@ def programSuspendContinuationNoParamNoSuspendContinuation: Int =
 
 def programSuspendContinuationNoParamResume: Int =
   def fooTest()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       println("Hello")
       continuation.resume(1)
     }
@@ -139,8 +139,8 @@ def programSuspendContinuationNoParamResume: Int =
 /*
 def programNestedContinuationCompilationError: Int =
   def fooTest()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation =>
-      val x = s.suspendContinuation[Int] { continuation1 => continuation1.resume(1) }
+    s.shift[Int] { continuation =>
+      val x = s.shift[Int] { continuation1 => continuation1.resume(1) }
       continuation.resume(x + 1)
     }
 
@@ -150,15 +150,15 @@ def programNestedContinuationCompilationError: Int =
 def programSuspendContinuationNoParamResumeIgnoreResult: Int =
   def fooTest()(using s: Suspend): Int =
     println("Start")
-    s.suspendContinuation[Unit] { _.resume(println("Hello")) }
+    s.shift[Unit] { _.resume(println("Hello")) }
     println("World")
     val x = 1
-    s.suspendContinuation[Boolean] { continuation =>
+    s.shift[Boolean] { continuation =>
       val q = "World"
       println("Hi")
       continuation.resume({ println(q); false })
     }
-//    s.suspendContinuation[Int] { continuation =>
+//    s.shift[Int] { continuation =>
 //      continuation.raise(new Exception("error"))
 //    }
     10
@@ -168,12 +168,12 @@ def programSuspendContinuationNoParamResumeIgnoreResult: Int =
 def programSuspendContinuationParamDependent: Int =
   def fooTest(qq: Int)(using s: Suspend): Int =
     val pp = 11
-    val xx = s.suspendContinuation[Int] { _.resume(qq - 1) }
+    val xx = s.shift[Int] { _.resume(qq - 1) }
     val ww = 13
     val rr = "AAA"
-    val yy = s.suspendContinuation[String] { c => c.resume(rr) }
+    val yy = s.shift[String] { c => c.resume(rr) }
     val tt = 100
-    val zz = s.suspendContinuation[Int] { _.resume(ww - 1 + xx) }
+    val zz = s.shift[Int] { _.resume(ww - 1 + xx) }
     println(xx)
     xx + qq + zz + pp + tt + yy.length
 
@@ -181,7 +181,7 @@ def programSuspendContinuationParamDependent: Int =
 
 def programSuspendContinuationResumeVals: Int =
   def fooTest()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Int] { c =>
+    summon[Suspend].shift[Int] { c =>
       c.resume {
         println("Hello")
         val x = 1
@@ -196,7 +196,7 @@ def programOneContinuationReturnValue: Int =
   def zeroArgumentsSingleResumeContinuationsBeforeAfter()(using Suspend): Int =
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x))
     }
     println("World")
@@ -225,7 +225,7 @@ object ExampleObject:
     def method2(x: Int) = x + 1
     val z2 = 1
 
-    val suspension1 = s.suspendContinuation[Int] { continuation =>
+    val suspension1 = s.shift[Int] { continuation =>
       def method3(x: Int) = x
       val z3 = 1
 
@@ -237,12 +237,12 @@ object ExampleObject:
       }
     }
 
-    s.suspendContinuation[Int] { continuation => continuation.resume(method1(x) + 1) }
+    s.shift[Int] { continuation => continuation.resume(method1(x) + 1) }
 
     val z5 = suspension1
     def method5(x: Int) = x
 
-    val suspension2 = s.suspendContinuation[Int] { continuation =>
+    val suspension2 = s.shift[Int] { continuation =>
       continuation.resume(z5 + suspension1 + method5(y))
     }
 

--- a/continuationsPluginExample/src/main/scala/examples/GenericArgumentsContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/GenericArgumentsContinuations.scala
@@ -4,9 +4,9 @@ import continuations.Suspend
 
 @main def GenericArgumentsContinuations =
   def genericArgumentsContinuations[A](x: A)(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
 
   println(genericArgumentsContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/GenericArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/GenericArgumentsSingleResumeContinuations.scala
@@ -5,5 +5,5 @@ import continuations.Suspend
 @main def GenericArgumentsSingleResumeContinuations =
   case class Foo(x: Int)
   def genericArgumentsSingleResumeContinuations[A](x: A)(using Suspend): A =
-    summon[Suspend].suspendContinuation(_.resume(x))
+    summon[Suspend].shift(_.resume(x))
   println(genericArgumentsSingleResumeContinuations(Foo(1)))

--- a/continuationsPluginExample/src/main/scala/examples/LeftContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/LeftContinuation.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 
 @main def LeftContinuation: Unit =
   def left()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       continuation.raise(new Exception("error"))
     }
   println(Try(left()))

--- a/continuationsPluginExample/src/main/scala/examples/ListMap.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ListMap.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def ListMap =
   def twoArgumentsOneContinuationsCFBefore(x: Int, y: Int): Suspend ?=> Int =
     val z = 1
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       continuation.resume(x + y + z)
     }
   val mappedContinuations = List(1, 2, 3, 4).map(twoArgumentsOneContinuationsCFBefore(1, _))

--- a/continuationsPluginExample/src/main/scala/examples/MultipleSuspendWithExpressionsInBody.scala
+++ b/continuationsPluginExample/src/main/scala/examples/MultipleSuspendWithExpressionsInBody.scala
@@ -5,10 +5,10 @@ import continuations.Suspend
 @main def MultipleSuspendWithExpressionsInBody =
   def foo1()(using s: Suspend): Int =
     println("Start")
-    s.suspendContinuation[Unit] { _.resume(println("Hello")) }
+    s.shift[Unit] { _.resume(println("Hello")) }
     println("World")
     val x = 1
-    s.suspendContinuation[Boolean] { continuation =>
+    s.shift[Boolean] { continuation =>
       val q = "World"
       println("Hi")
       continuation.resume({ println(q); false })

--- a/continuationsPluginExample/src/main/scala/examples/NonCompanionObjectContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/NonCompanionObjectContinuations.scala
@@ -14,7 +14,7 @@ object ExampleObj:
     def method2(x: Int) = x + 1
     val z2 = 1
 
-    val suspension1 = s.suspendContinuation[Int] { continuation =>
+    val suspension1 = s.shift[Int] { continuation =>
       def method3(x: Int) = x
       val z3 = 1
 
@@ -26,12 +26,12 @@ object ExampleObj:
       }
     }
 
-    s.suspendContinuation[Int] { continuation => continuation.resume(method1(x) + 1) }
+    s.shift[Int] { continuation => continuation.resume(method1(x) + 1) }
 
     val z5 = suspension1
     def method5(x: Int) = x
 
-    val suspension2 = s.suspendContinuation[Int] { continuation =>
+    val suspension2 = s.shift[Int] { continuation =>
       continuation.resume(z5 + suspension1 + method5(y))
     }
 

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentOneContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentOneContinuations.scala
@@ -6,7 +6,7 @@ import continuations.Suspend
   given String = "Output: "
   def oneArgumentOneAdditionalGivenArgumentOneContinuations(
       x: Int)(using Suspend, String): String =
-    summon[Suspend].suspendContinuation[String] { continuation =>
+    summon[Suspend].shift[String] { continuation =>
       continuation.resume(summon[String] + x)
     }
   println(oneArgumentOneAdditionalGivenArgumentOneContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentOneAdditionalGivenArgumentTwoContinuations.scala
@@ -6,8 +6,8 @@ import continuations.Suspend
   given String = "Output: "
   def oneArgumentOneAdditionalGivenArgumentTwoContinuations(
       x: Int)(using Suspend, String): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(summon[String] + x))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
   println(oneArgumentOneAdditionalGivenArgumentTwoContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentSingleResumeContinuationsCodeAfter.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentSingleResumeContinuationsCodeAfter.scala
@@ -4,6 +4,6 @@ import continuations.Suspend
 
 @main def OneArgumentSingleResumeContinuationsCodeAfter =
   def oneArgumentSingleResumeContinuationsCodeAfter(str: String)(using s: Suspend): Int =
-    s.suspendContinuation(_.resume(println(str)))
+    s.shift(_.resume(println(str)))
     10
   println(oneArgumentSingleResumeContinuationsCodeAfter("Hello"))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsOneContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsOneContinuationsCF.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def OneArgumentsOneContinuationsCF =
   def oneArgumentsOneContinuationsCF(x: Int): Suspend ?=> Int =
-    summon[Suspend].suspendContinuation { _.resume(x + 1) }
+    summon[Suspend].shift { _.resume(x + 1) }
   println(oneArgumentsOneContinuationsCF(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuations.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def OneArgumentsSingleResumeContinuations =
   def oneArgumentsSingleResumeContinuations(x: Int)(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation => continuation.resume(x + 1) }
+    s.shift[Int] { continuation => continuation.resume(x + 1) }
   println(oneArgumentsSingleResumeContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuationsBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsSingleResumeContinuationsBefore.scala
@@ -6,5 +6,5 @@ import continuations.Suspend
   def oneArgumentsSingleResumeContinuationsBefore(x: Int)(using Suspend): Int =
     println("Hello")
     val y = x
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
   println(oneArgumentsSingleResumeContinuationsBefore(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuations.scala
@@ -4,6 +4,6 @@ import continuations.Suspend
 
 @main def OneArgumentsTwoContinuations =
   def oneArgumentsTwoContinuations(x: Int)(using s: Suspend): Int =
-    s.suspendContinuation[Unit] { continuation => continuation.resume(println(x)) }
-    s.suspendContinuation[Int] { continuation => continuation.resume(1) }
+    s.shift[Unit] { continuation => continuation.resume(println(x)) }
+    s.shift[Int] { continuation => continuation.resume(1) }
   println(oneArgumentsTwoContinuations(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArgumentsTwoContinuationsCF.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def OneArgumentsTwoContinuationsCF =
   def oneArgumentsTwoContinuationsCF(x: Int): Suspend ?=> Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
   println(oneArgumentsTwoContinuationsCF(1))

--- a/continuationsPluginExample/src/main/scala/examples/OneArugmentsTwoContinuationsTwoResumes.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneArugmentsTwoContinuationsTwoResumes.scala
@@ -4,6 +4,6 @@ import continuations.Suspend
 
 @main def OneFunctionArgumentTwoContinuationsTwoResumes =
   def oneFunctionArgumentTwoContinuationsTwoResumes(f: Int => Int)(using s: Suspend): Int =
-    s.suspendContinuation(_.resume(println(f(1))))
-    s.suspendContinuation(_.resume(f(2)))
+    s.shift(_.resume(println(f(1))))
+    s.shift(_.resume(f(2)))
   println(oneFunctionArgumentTwoContinuationsTwoResumes(_ + 1))

--- a/continuationsPluginExample/src/main/scala/examples/OneFunctionParameterOneResume.scala
+++ b/continuationsPluginExample/src/main/scala/examples/OneFunctionParameterOneResume.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def OneFunctionParameterOneResume =
   def foo(f: Int => Int)(using s: Suspend): Int =
-    s.suspendContinuation(_.resume(f(1)))
+    s.shift(_.resume(f(1)))
   println(foo(_ + 1))

--- a/continuationsPluginExample/src/main/scala/examples/ProgramMultipleSuspendLeft.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ProgramMultipleSuspendLeft.scala
@@ -5,6 +5,6 @@ import scala.util.Try
 
 @main def ProgramMultipleSuspendLeft =
   def foo()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { _.raise(new Exception("error")) }
-    s.suspendContinuation[Int] { _.resume({ println("Resume2"); 2 }) }
+    s.shift[Int] { _.raise(new Exception("error")) }
+    s.shift[Int] { _.resume({ println("Resume2"); 2 }) }
   println(Try(foo()))

--- a/continuationsPluginExample/src/main/scala/examples/ResumeWithValsInsideTheContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ResumeWithValsInsideTheContinuation.scala
@@ -4,7 +4,7 @@ import continuations.Suspend
 
 @main def ResumeWithValsInsideTheContinuation =
   def resumeWithValsInsideTheContinuation()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       val x = 1
       val y = 2
       continuation.resume(x + y)

--- a/continuationsPluginExample/src/main/scala/examples/ThreeDependentContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ThreeDependentContinuations.scala
@@ -5,10 +5,10 @@ import continuations.*
 @main def ThreeDependentContinuations =
   def threeDependentContinuations(a: Int, b: Int, c: Int)(using s: Suspend): Int =
     val d = 4
-    val continuationOne: Int = s.suspendContinuation(_.resume(d + a))
+    val continuationOne: Int = s.shift(_.resume(d + a))
     val e = 5
-    val continuationTwo: Int = s.suspendContinuation(_.resume(continuationOne + e + b))
+    val continuationTwo: Int = s.shift(_.resume(continuationOne + e + b))
     val f = 6
-    val result: Int = s.suspendContinuation(_.resume(continuationTwo + f + c))
+    val result: Int = s.shift(_.resume(continuationTwo + f + c))
     result
   println(threeDependentContinuations(1, 2, 3))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsOneContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsOneContinuationsCF.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def TwoArgumentsOneContinuationsCF =
   def twoArgumentsOneContinuationsCF(x: Int, y: Int): Suspend ?=> Int =
-    summon[Suspend].suspendContinuation[Int](_.resume(x + y + 1))
+    summon[Suspend].shift[Int](_.resume(x + y + 1))
   println(twoArgumentsOneContinuationsCF(1, 1))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuations.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def TwoArgumentsSingleResumeContinuations =
   def twoArgumentsSingleResumeContinuations(x: Int, y: Int)(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation => continuation.resume(x + y + 1) }
+    s.shift[Int] { continuation => continuation.resume(x + y + 1) }
   println(twoArgumentsSingleResumeContinuations(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsBefore.scala
@@ -6,5 +6,5 @@ import continuations.Suspend
   def twoArgumentsSingleResumeContinuationsBefore(x: Int, y: Int)(using s: Suspend): Int =
     println("Hello")
     val z = x + y
-    s.suspendContinuation(_.resume(1))
+    s.shift(_.resume(1))
   println(twoArgumentsSingleResumeContinuationsBefore(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsBeforeUsedInResume.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsBeforeUsedInResume.scala
@@ -7,5 +7,5 @@ import continuations.Suspend
       using s: Suspend): Int =
     println("Hello")
     val z = 1
-    s.suspendContinuation[Int] { continuation => continuation.resume(x + y + z) }
+    s.shift[Int] { continuation => continuation.resume(x + y + z) }
   println(twoArgumentsSingleResumeContinuationsBeforeUsedInResume(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsCodeAfter.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsSingleResumeContinuationsCodeAfter.scala
@@ -4,6 +4,6 @@ import continuations.Suspend
 
 @main def TwoArgumentsSingleResumeContinuationsCodeAfter =
   def twoArgumentsSingleResumeContinuationsCodeAfter(x: Int, y: Int)(using s: Suspend): Int =
-    s.suspendContinuation(_.resume(println(x)))
+    s.shift(_.resume(println(x)))
     y
   println(twoArgumentsSingleResumeContinuationsCodeAfter(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def TwoArgumentsTwoContinuations =
   def twoArgumentsTwoContinuations(x: Int, y: Int)(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
   println(twoArgumentsTwoContinuations(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoContinuationsCF.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def TwoArgumentsTwoContinuationsCF =
   def twoArgumentsTwoContinuationsCF(x: Int, y: Int): Suspend ?=> Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(3))
+    summon[Suspend].shift[Int](continuation => continuation.resume(3))
   println(twoArgumentsTwoContinuationsCF(1, 2))

--- a/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoDependentContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoArgumentsTwoDependentContinuations.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def TwoArgumentsTwoDependentContinuations =
   def twoArgumentsTwoDependentContinuations(x: Int, y: Int)(using s: Suspend): Int = {
-    val z = s.suspendContinuation[Int] { _.resume(x + y + 1) }
-    s.suspendContinuation[Int] { _.resume(z + 1) }
+    val z = s.shift[Int](_.resume(x + y + 1))
+    s.shift[Int](_.resume(z + 1))
   }
 
   println(twoArgumentsTwoDependentContinuations(1, 1))

--- a/continuationsPluginExample/src/main/scala/examples/TwoContinuationsUseCodeAboveContinuationInCodeAfterTheContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoContinuationsUseCodeAboveContinuationInCodeAfterTheContinuation.scala
@@ -7,7 +7,7 @@ import continuations.Suspend
       using s: Suspend): Int =
     println("Hello")
     val x = 1
-    s.suspendContinuation(_.resume(println("Resume 1")))
-    s.suspendContinuation(_.resume(println(s"Resume 2 $x")))
+    s.shift(_.resume(println("Resume 1")))
+    s.shift(_.resume(println(s"Resume 2 $x")))
     x + 1
   println(twoContinuationsUseCodeAboveContinuationInCodeAfterTheContinuation())

--- a/continuationsPluginExample/src/main/scala/examples/TwoContinuationsUseCodeAboveContinuationsInCodeBetweenContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoContinuationsUseCodeAboveContinuationsInCodeBetweenContinuations.scala
@@ -6,8 +6,8 @@ import continuations.Suspend
   def twoContinuationsUseCodeAboveContinuationsInCodeBetweenContinuations()(
       using s: Suspend): Int =
     val x = 1
-    s.suspendContinuation(_.resume(println("Resume 1")))
+    s.shift(_.resume(println("Resume 1")))
     val y = 1
-    s.suspendContinuation(_.resume(println(s"Resume 2: ${x + y}")))
+    s.shift(_.resume(println(s"Resume 2: ${x + y}")))
     10
   println(twoContinuationsUseCodeAboveContinuationsInCodeBetweenContinuations())

--- a/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsOneContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsOneContinuations.scala
@@ -4,7 +4,7 @@ import continuations.Suspend
 
 @main def TwoCurriedArgumentsOneContinuations =
   def twoCurriedArgumentsOneContinuations(x: Int)(y: Int)(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       continuation.resume(x + y + 1)
     }
   println(twoCurriedArgumentsOneContinuations(1)(1))

--- a/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/TwoCurriedArgumentsTwoContinuations.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def TwoCurriedArgumentsTwoContinuations =
   def twoCurriedArgumentsTwoContinuations(x: Int)(y: Int)(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(3) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(3) }
   println(twoCurriedArgumentsTwoContinuations(1)(2))

--- a/continuationsPluginExample/src/main/scala/examples/UseValsDefinedInsideContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/UseValsDefinedInsideContinuation.scala
@@ -4,7 +4,7 @@ import continuations.Suspend
 
 @main def UseValsDefinedInsideContinuation =
   def useValsDefinedInsideContinuation()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       val x = 1
       val y = 2
       x + y

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeAfter.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeAfter.scala
@@ -4,10 +4,10 @@ import continuations.Suspend
 
 @main def ZeroArgumentsCodeAfter =
   def zeroArgumentsCodeAfter()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(2))
     }
     3

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBefore.scala
@@ -6,8 +6,8 @@ import continuations.Suspend
   def zeroArgumentsCodeBefore()(using Suspend): Int =
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsCodeBefore())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBetween.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsCodeBetween.scala
@@ -4,10 +4,10 @@ import continuations.Suspend
 
 @main def ZeroArgumentsCodeBetween =
   def zeroArgumentsCodeBetween()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(1))
     }
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsCodeBetween())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsMultipleResume.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsMultipleResume.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 
 @main def ZeroArgumentsMultipleResume =
   def zeroArgumentsMultipleResume()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { c =>
+    s.shift[Int] { c =>
       c.resume( { println("Resume1"); 1 })
       c.resume( { println("Resume2"); 2 })
     }

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsOneContinuationCodeBeforeUsedAfter.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsOneContinuationCodeBeforeUsedAfter.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def ZeroArgumentsOneContinuationCodeBeforeUsedAfter =
   def zeroArgumentsOneContinuationCodeBeforeUsedAfter()(using s: Suspend): Int =
     val x = 1
-    s.suspendContinuation[Unit](_.resume(println("Hello")))
+    s.shift[Unit](_.resume(println("Hello")))
     val y = 1
     x + y
   println(zeroArgumentsOneContinuationCodeBeforeUsedAfter())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsOneContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsOneContinuationsCF.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def ZeroArgumentsOneContinuationsCF =
   def zeroArgumentsOneContinuationsCF(): Suspend ?=> Int =
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
   println(zeroArgumentsOneContinuationsCF())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuations.scala
@@ -4,5 +4,5 @@ import continuations.Suspend
 
 @main def ZeroArgumentsSingleResumeContinuations =
   def zeroArgumentsSingleResumeContinuations()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { continuation => continuation.resume(1) }
+    s.shift[Int] { continuation => continuation.resume(1) }
   println(zeroArgumentsSingleResumeContinuations())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuationsBefore.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuationsBefore.scala
@@ -6,5 +6,5 @@ import continuations.Suspend
   def zeroArgumentsSingleResumeContinuationsBefore()(using Suspend): Int =
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
   println(zeroArgumentsSingleResumeContinuationsBefore())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuationsCodeAfter.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsSingleResumeContinuationsCodeAfter.scala
@@ -4,6 +4,6 @@ import continuations.Suspend
 
 @main def ZeroArgumentsSingleResumeContinuationsCodeAfter =
   def zeroArgumentsSingleResumeContinuationsCodeAfter()(using s: Suspend): Int =
-    s.suspendContinuation { completion => completion.resume(println("Hi")) }
+    s.shift { completion => completion.resume(println("Hi")) }
     10
   println(zeroArgumentsSingleResumeContinuationsCodeAfter())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuations.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuations.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def ZeroArgumentsTwoContinuations =
   def zeroArgumentsTwoContinuations()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsTwoContinuations())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuationsCF.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuationsCF.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def ZeroArgumentsTwoContinuationsCF =
   def zeroArgumentsTwoContinuationsCF(): Suspend ?=> Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(1))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(2) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(2) }
   println(zeroArgumentsTwoContinuationsCF())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuationsMultipleResume.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsTwoContinuationsMultipleResume.scala
@@ -6,8 +6,8 @@ import scala.util.Try
 
 @main def ZeroArgumentsTwoContinuationsMultipleResume =
   def zeroArgumentsTwoContinuationsMultipleResume()(using s: Suspend): Int =
-    s.suspendContinuation[Int] { c => c.resume({ println("Resume1"); 1 }) }
-    s.suspendContinuation[Int] { c =>
+    s.shift[Int] { c => c.resume({ println("Resume1"); 1 }) }
+    s.shift[Int] { c =>
       c.resume({ println("Resume2"); 1 })
       c.resume({ println("Resume3"); 2 })
     }

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedAboveContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedAboveContinuation.scala
@@ -6,9 +6,9 @@ import continuations.Suspend
   def zeroArgumentsValsDefinedAboveContinuation()(using Suspend): Int =
     println("Hello")
     val x = 1
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x))
     }
     val y = 2
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(y) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(y) }
   println(zeroArgumentsValsDefinedAboveContinuation())

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedInsideContinuation.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedInsideContinuation.scala
@@ -4,12 +4,12 @@ import continuations.Suspend
 
 @main def ZeroArgumentsValsDefinedInsideContinuation =
   def zeroArgumentsValsDefinedInsideContinuation()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       val x = 1
       continuation.resume(println(x))
     }
     val x = 1
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       val x = 2
       continuation.resume(x)
     }

--- a/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedInsideResume.scala
+++ b/continuationsPluginExample/src/main/scala/examples/ZeroArgumentsValsDefinedInsideResume.scala
@@ -4,14 +4,14 @@ import continuations.Suspend
 
 @main def ZeroArgumentsValsDefinedInsideResume =
   def zeroArgumentsValsDefinedInsideResume()(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume {
         val x = 1
         println(x)
       }
     }
 
-    summon[Suspend].suspendContinuation[Int] { continuation =>
+    summon[Suspend].shift[Int] { continuation =>
       continuation.resume {
         val x = 2
         x

--- a/docs/SIP.md
+++ b/docs/SIP.md
@@ -171,12 +171,12 @@ suspend def startContinuationUninterceptedOrReturn[T](
 Starts a continuation and executes it until its first suspension point. Returns the result of the computation or ContinuationSuspended if this continuation should remain in suspended state. 
 When the implementer returns `ContinuationSuspended` it invokes `completion` as the continuation computation completes.
 
-##### suspendContinuationUninterceptedOrReturn
+##### shiftUninterceptedOrReturn
 
 ```scala
 object ContinuationSuspended
 
-suspend def suspendContinuationUninterceptedOrReturn[T](
+suspend def shiftUninterceptedOrReturn[T](
   block: Continuation[T] => T | ContinuationSuspended.type
 ): T
 ```

--- a/list-map/src/main/scala/examples/ListMap.scala
+++ b/list-map/src/main/scala/examples/ListMap.scala
@@ -5,6 +5,6 @@ import continuations.Suspend
 @main def ListMap =
   def twoArgumentsOneContinuationsCFBefore(x: Int, y: Int): Suspend ?=> Int =
     val z = 1
-    summon[Suspend].suspendContinuation(_.resume(x + y + z))
+    summon[Suspend].shift(_.resume(x + y + z))
   val mappedContinuations = List(1, 2, 3, 4).map(twoArgumentsOneContinuationsCFBefore(1, _))
   println(mappedContinuations)

--- a/list-map/src/main/scala/examples/NonblockingNonwaitingResume.scala
+++ b/list-map/src/main/scala/examples/NonblockingNonwaitingResume.scala
@@ -18,7 +18,7 @@ given ExecutorService = Executors.newWorkStealingPool()
       y: Int): Suspend ?=> Int | Continuation.State.Suspended.type =
     println("twoArgumentsOneContinuationsCFBefore")
     val z = 1
-    summon[Suspend].suspendContinuation[Int] { c =>
+    summon[Suspend].shift[Int] { c =>
       summon[ExecutorService].submit(new Runnable {
         override def run =
           val sleepTime = Random.between(10, 5000)

--- a/list-map/src/main/scala/examples/ThreeDependentContinuations.scala
+++ b/list-map/src/main/scala/examples/ThreeDependentContinuations.scala
@@ -5,11 +5,11 @@ import continuations.*
 @main def ThreeDependentContinuations =
   def threeDependentContinuations(a: Int, b: Int, c: Int)(using s: Suspend): Int =
     val d = 4
-    val continuationOne: Int = s.suspendContinuation(_.resume(d + a)) // 5
+    val continuationOne: Int = s.shift(_.resume(d + a)) // 5
     val e = 5
     val continuationTwo: Int =
-      s.suspendContinuation(_.resume(continuationOne + e + b)) // 12
+      s.shift(_.resume(continuationOne + e + b)) // 12
     val f = 6
-    val result: Int = s.suspendContinuation(_.resume(continuationTwo + f + c)) // 21
+    val result: Int = s.shift(_.resume(continuationTwo + f + c)) // 21
     result
   println(threeDependentContinuations(1, 2, 3))

--- a/two-arguments-two-continuations/src/main/scala/examples/ProgramSuspendingContinuationNoParamResumeIgnoreResult.scala
+++ b/two-arguments-two-continuations/src/main/scala/examples/ProgramSuspendingContinuationNoParamResumeIgnoreResult.scala
@@ -5,15 +5,15 @@ import continuations.*
 @main def ProgramSuspendingContinuationNoParamResumeIgnoreResult =
   def fooTest()(using s: Suspend): Int =
     println("Start")
-    s.suspendContinuation[Unit] { _.resume({ println("Hello") }) }
+    s.shift[Unit] { _.resume({ println("Hello") }) }
     println("World")
     val x = 1
-    s.suspendContinuation[Boolean] { continuation =>
+    s.shift[Boolean] { continuation =>
       val q = "World"
       println("Hi")
       continuation.resume({ println(q); false })
     }
-    s.suspendContinuation[Int] { continuation =>
+    s.shift[Int] { continuation =>
       continuation.raise(new Exception("error"))
     }
     10

--- a/two-arguments-two-continuations/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
+++ b/two-arguments-two-continuations/src/main/scala/examples/TwoArgumentsTwoContinuations.scala
@@ -4,8 +4,8 @@ import continuations.Suspend
 
 @main def TwoArgumentsTwoContinuations =
   def twoArgumentsTwoContinuations(x: Int, y: Int)(using Suspend): Int =
-    summon[Suspend].suspendContinuation[Unit] { continuation =>
+    summon[Suspend].shift[Unit] { continuation =>
       continuation.resume(println(x + y))
     }
-    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(1) }
+    summon[Suspend].shift[Int] { continuation => continuation.resume(1) }
   println(twoArgumentsTwoContinuations(1, 2))

--- a/zero-arguments-one-continuation-code-before-used-after/src/main/scala/examples/ZeroArgumentsOneContinuationCodeBeforeUsedAfter.scala
+++ b/zero-arguments-one-continuation-code-before-used-after/src/main/scala/examples/ZeroArgumentsOneContinuationCodeBeforeUsedAfter.scala
@@ -5,7 +5,7 @@ import continuations.Suspend
 @main def ZeroArgumentsOneContinuationCodeBeforeUsedAfter =
   def zeroArgumentsOneContinuationCodeBeforeUsedAfter()(using s: Suspend): Int =
     val x = 1
-    s.suspendContinuation[Unit](_.resume(println("Hello")))
+    s.shift[Unit](_.resume(println("Hello")))
     val y = 1
     x + y
   println(zeroArgumentsOneContinuationCodeBeforeUsedAfter())


### PR DESCRIPTION
Although it is a bit more "obscure" than the words `suspendContinuation`, the word `shift` is more common in the Continuation / Delimited Continuation lore.