### PR TITLE
DefDeftransforms - Small refactor to code 

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -1117,6 +1117,9 @@ object DefDefTransforms extends TreesChecks:
               gvSym.fold(vd)(gv => tpd.Assign(ref(gv), vd.rhs))
             case _ => tree
 
+        val incrementLabel =
+          tpd.Assign(ref(contSymbol).select(labelVarParam), tpd.Literal(Constant(stateIx + 1)))
+
         val orThrowMatch: tpd.Match = {
           val orThrowSymbol: TermSymbol =
             newSymbol(
@@ -1164,9 +1167,7 @@ object DefDefTransforms extends TreesChecks:
           rowsBefore.map(updateForGlobalVars),
           assignToIPairs.map(assignToI),
           List(
-            tpd.Assign(
-              ref(contSymbol).select(labelVarParam),
-              tpd.Literal(Constant(stateIx + 1))),
+            incrementLabel,
             safeContinuation,
             transformSuspendContinuationBody(callSuspensionPoint, safeContinuation.symbol),
             orThrowMatch

--- a/continuationsPlugin/src/test/resources/StateMachineForSuspendContinuationReturningANonSuspendingVal.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineForSuspendContinuationReturningANonSuspendingVal.scala
@@ -62,8 +62,7 @@ package continuations {
                         case continuations.Continuation.State.Suspended => return continuations.Continuation.State.Suspended
                         case orThrow @ <empty> => ()
                       }
-                  case 1 => 
-                    continuations.Continuation.checkResult($continuation.$result)
+                  case 1 => continuations.Continuation.checkResult($continuation.$result)
                   case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
                 }
             }

--- a/continuationsPlugin/src/test/resources/StateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal.scala
@@ -92,8 +92,7 @@ package continuations {
                         case continuations.Continuation.State.Suspended => return continuations.Continuation.State.Suspended
                         case orThrow @ <empty> => ()
                       }
-                  case 3 => 
-                    continuations.Continuation.checkResult($continuation.$result)
+                  case 3 => continuations.Continuation.checkResult($continuation.$result)
                   case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
                 }
             }

--- a/continuationsPlugin/src/test/resources/StateMachineReturningANonSuspendedValue.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineReturningANonSuspendedValue.scala
@@ -82,8 +82,7 @@ package continuations {
                         case continuations.Continuation.State.Suspended => return continuations.Continuation.State.Suspended
                         case orThrow @ <empty> => ()
                       }
-                  case 2 => 
-                    continuations.Continuation.checkResult($continuation.$result)
+                  case 2 => continuations.Continuation.checkResult($continuation.$result)
                   case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
                 }
             }

--- a/continuationsPlugin/src/test/resources/StateMachineWithMultipleResumeReturningANonSuspendedValue.scala
+++ b/continuationsPlugin/src/test/resources/StateMachineWithMultipleResumeReturningANonSuspendedValue.scala
@@ -97,8 +97,7 @@ package continuations {
                         case continuations.Continuation.State.Suspended => return continuations.Continuation.State.Suspended
                         case orThrow @ <empty> => ()
                       }
-                  case 3 => 
-                    continuations.Continuation.checkResult($continuation.$result)
+                  case 3 => continuations.Continuation.checkResult($continuation.$result)
                   case _ => throw new IllegalArgumentException("call to \'resume\' before \'invoke\' with coroutine")
                 }
             }


### PR DESCRIPTION
- Extract a couple of auxiliary query functions
- Separate the definition of the symbols from the creation of the `ValDef` definitions, and try to pass the symbols rather than the trees around. 
